### PR TITLE
Specify resolve strategy so calls don't go to owner first

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
@@ -154,6 +154,7 @@ public class License extends SourceTask implements VerificationTask {
     public void mapping(Closure closure) {
         Map<String,String> tmpMap = new HashMap<String,String>();
         closure.delegate = tmpMap;
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
         closure();
         internalMappings.putAll(tmpMap);
     }

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseExtension.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseExtension.groovy
@@ -74,6 +74,7 @@ class LicenseExtension {
     public void mapping(Closure closure) {
         Map<String,String> tmpMap = new HashMap<String,String>()
         closure.delegate = tmpMap;
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
         closure();
         internalMappings.putAll(tmpMap);
     }


### PR DESCRIPTION
Fix for #5, which is a breakage for any custom mappings.
