### PR TITLE
fix "ignoreFailures=false does not fail build" (issue #13)

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
@@ -116,7 +116,7 @@ public class License extends SourceTask implements VerificationTask {
         didWork = !altered.isEmpty()
 
         if (!ignoreFailures && callback.hadFailure()) {
-            throw new StopActionException("License violations were found")
+            throw new GradleException("License violations were found")
         }
 
     }


### PR DESCRIPTION
StopActionException only causes that action to stop, and continues the build with the next action.
I've changed it to instead throw GradleException, following the lead of the Test task.

http://www.gradle.org/docs/current/javadoc/org/gradle/api/tasks/StopActionException.html
