### PR TITLE
suppress deprecated warning

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
@@ -122,14 +122,14 @@ class LicensePlugin implements Plugin<Project> {
                 def sourceSetTaskName = sourceSet.getTaskName(taskBaseName, null)
                 logger.info("Adding license tasks for sourceSet ${sourceSetTaskName}");
 
-                License checkTask = project.tasks.add(sourceSetTaskName, License)
+                License checkTask = project.tasks.create(sourceSetTaskName, License)
                 checkTask.check = true
                 configureForSourceSet(sourceSet, checkTask)
                 baseCheckTask.dependsOn checkTask
 
                 // Add independent license task, which will perform format
                 def sourceSetFormatTaskName = sourceSet.getTaskName(taskBaseName + 'Format', null)
-                License formatTask = project.tasks.add(sourceSetFormatTaskName, License)
+                License formatTask = project.tasks.create(sourceSetFormatTaskName, License)
                 formatTask.check = false
                 configureForSourceSet(sourceSet, formatTask)
                 baseFormatTask.dependsOn formatTask


### PR DESCRIPTION
suppress Gradle 1.6 deprecated warning.

warning message from gradle 1.6 is: "The TaskContainer.add() method has been deprecated and is scheduled to be removed in Gradle 2.0. Please use the create() method instead."
