### PR TITLE
fixed issue with license check and skipExistingHeaders

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/maven/LicenseCheckMojo.java
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/maven/LicenseCheckMojo.java
@@ -48,7 +48,8 @@ public final class LicenseCheckMojo implements CallbackWithFailure {
 
     @Override
     public void onHeaderNotFound(Document document, Header header) {
-        if (skipExistingHeaders) {
+        document.parseHeader();
+        if (document.headerDetected() && skipExistingHeaders) {
             logger.lifecycle("Ignoring header in: {}", DocumentFactory.getRelativeFile(basedir, document));
             return;
         } else {

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/LicenseIntegTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/LicenseIntegTest.groovy
@@ -181,6 +181,17 @@ key2 = value2
         assert licenseTask.altered.size()  == 0
     }
 
+    @Test
+    public void shouldDetectMissingHeaderIfCheckIsTrueAndSkipExistingHeadersIsTrue() {
+        createPropertiesFile()
+
+        licenseTask.check = true
+        licenseTask.skipExistingHeaders = true
+        licenseTask.execute()
+
+        assert licenseTask.altered.size() == 1
+    }
+
     public File createLicenseFile() {
         File file = project.file("LICENSE")
         Files.createParentDirs(file);


### PR DESCRIPTION
If skipExistingHeaders is true, license check does not distinguish between files with a different header and files with no headers.  The correct behavior should be files with a different header are ignored and files with no header are reported.  This pull request adds a test which exposes the issue and adds a fix.
