### PR TITLE
Apply license plugin to itself

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'license'
 
 group = 'nl.javadude.gradle.plugins'
 
@@ -37,6 +38,10 @@ task sourcesJar(type: Jar) {
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
+}
+
+license {
+	ignoreFailures true
 }
 
 artifacts { archives sourcesJar, javadocJar }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,25 @@
+apply plugin: 'groovy'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile ('com.mycila.maven-license-plugin:maven-license-plugin:1.10.b1') {
+        exclude group: 'org.apache.maven', module: 'maven-plugin-api'
+        exclude group: 'org.apache.maven', module: 'maven-project'
+    }
+    compile 'com.google.guava:guava:15.0'
+    compile gradleApi()
+}
+
+sourceSets {
+    main {
+        groovy {
+            srcDir '../src/main/groovy'
+        }
+        resources {
+            srcDir '../src/main/resources'
+        }
+    }
+}


### PR DESCRIPTION
Ironically, the source files in the license plugin (mostly) have no license.  

This change will allow the license plugin to be applied to its own build file (isn't Gradle awesome!).  I've configured it to ignoreFailures in case you want to update LICENSE before applying it to the project.
