### PR TITLE
Adds extension property to specify encoding which is used to open files

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
@@ -63,6 +63,11 @@ public class License extends SourceTask implements VerificationTask {
     
     boolean strictCheck
 
+    /**
+     * The encoding used to open files
+     */
+    String encoding
+
     @InputFile
     File header
 
@@ -95,7 +100,7 @@ public class License extends SourceTask implements VerificationTask {
         Map<String, String> initial = combineVariables();
         Map<String, String> combinedMappings = combinedMappings();
 
-        new AbstractLicenseMojo(validHeaders, getProject().rootDir, initial, isDryRun(), isSkipExistingHeaders(), isUseDefaultMappings(), isStrictCheck(), getHeader(), source, combinedMappings)
+        new AbstractLicenseMojo(validHeaders, getProject().rootDir, initial, isDryRun(), isSkipExistingHeaders(), isUseDefaultMappings(), isStrictCheck(), getHeader(), source, combinedMappings, getEncoding())
             .execute(callback);
 
         altered = callback.getAffected()

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseExtension.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseExtension.groovy
@@ -68,6 +68,11 @@ class LicenseExtension {
 
     boolean strictCheck
 
+    /**
+     * The encoding used for opening files. It is the system encoding by default
+     */
+    String encoding
+
     Map<String, String> internalMappings = new HashMap<String, String>();
     public void mapping(String fileType, String headerType) {
         internalMappings.put(fileType, headerType);

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
@@ -88,6 +88,7 @@ class LicensePlugin implements Plugin<Project> {
             skipExistingHeaders = false
             useDefaultMappings = true
             strictCheck = false
+            encoding = System.properties['file.encoding']
             conventionMapping.with {
                 sourceSets = { [] }
             }
@@ -194,6 +195,7 @@ class LicensePlugin implements Plugin<Project> {
             inheritedMappings = { extension.internalMappings }
             excludes = { extension.excludePatterns }
             includes = { extension.includePatterns }
+            encoding = { extension.encoding }
         }
     }
 

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/maven/AbstractLicenseMojo.java
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/maven/AbstractLicenseMojo.java
@@ -64,7 +64,7 @@ public class AbstractLicenseMojo {
         this.header = header;
         this.source = source;
         this.mapping = mapping;
-	this.encoding = encoding;
+        this.encoding = encoding;
     }
 
     protected void execute(final Callback callback) throws MalformedURLException {

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/maven/AbstractLicenseMojo.java
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/maven/AbstractLicenseMojo.java
@@ -64,7 +64,7 @@ public class AbstractLicenseMojo {
         this.header = header;
         this.source = source;
         this.mapping = mapping;
-		this.encoding = encoding;
+	this.encoding = encoding;
     }
 
     protected void execute(final Callback callback) throws MalformedURLException {

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/maven/AbstractLicenseMojo.java
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/maven/AbstractLicenseMojo.java
@@ -39,7 +39,7 @@ public class AbstractLicenseMojo {
     protected String[] keywords = new String[] { "copyright" };
     protected String[] headerDefinitions = new String[0]; // TODO Not sure how a user would specify
     protected HeaderSection[] headerSections = new HeaderSection[0];
-    protected String encoding = System.getProperty("file.encoding");
+    protected String encoding;
     protected float concurrencyFactor = 1.5f;
     protected Map<String, String> mapping;
     
@@ -50,9 +50,9 @@ public class AbstractLicenseMojo {
     File header;
     FileCollection source;
 
-    public AbstractLicenseMojo(Collection<File> validHeaders, File rootDir, Map<String, String> initial,
-                    boolean dryRun, boolean skipExistingHeaders, boolean useDefaultMappings, boolean strictCheck,
-                    File header, FileCollection source, Map<String, String> mapping) {
+    public AbstractLicenseMojo(Collection<File> validHeaders, File rootDir, Map<String, String> initial, boolean dryRun,
+			boolean skipExistingHeaders, boolean useDefaultMappings, boolean strictCheck, File header, FileCollection source,
+			Map<String, String> mapping, String encoding) {
         super();
         this.validHeaders = validHeaders;
         this.rootDir = rootDir;
@@ -64,6 +64,7 @@ public class AbstractLicenseMojo {
         this.header = header;
         this.source = source;
         this.mapping = mapping;
+		this.encoding = encoding;
     }
 
     protected void execute(final Callback callback) throws MalformedURLException {


### PR DESCRIPTION
We encountered a problem formatting files with arabic letters on Windows machines. Allowing to specify the encoding used to open files would solve these kind of problems.