### PR TITLE
Source set ordering

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
@@ -61,8 +61,6 @@ class LicensePlugin implements Plugin<Project> {
         extension = createExtension()
         downloadLicensesExtension = createDownloadLicensesExtension()
 
-        
-        
         project.plugins.with {
             
             withType(JavaBasePlugin) {
@@ -74,8 +72,6 @@ class LicensePlugin implements Plugin<Project> {
             }
 
         }
-        
-        
     }
 
     protected LicenseExtension createExtension() {
@@ -202,7 +198,10 @@ class LicensePlugin implements Plugin<Project> {
     private void configureJava() {
         
         configureExtensionRule(JavaBasePlugin)
-        configureSourceSetRule()
+        project.afterEvaluate {
+            // Since we're going to look at the extension, we need to run late enough to let the user configure it
+            configureSourceSetRule()
+        }
         configureTaskRule()
         
     }

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
@@ -250,7 +250,10 @@ class LicensePlugin implements Plugin<Project> {
 
     private void configureAndroid() {
         configureExtensionRule(AppPlugin)
-        configureAndroidSourceSetRule()
+        project.afterEvaluate {
+            // Since we're going to look at the extension, we need to run late enough to let the user configure it
+            configureAndroidSourceSetRule()
+        }
         configureTaskRule()
         
     }

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/LicenseIntegTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/LicenseIntegTest.groovy
@@ -37,7 +37,8 @@ class LicenseIntegTest {
         projectDir = Files.createTempDir()
         project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.apply plugin: 'java'
-        project.apply plugin: 'license'
+        def plugin = project.plugins.apply(LicensePlugin)
+        plugin.configureSourceSetRule()
 
         project.license.ignoreFailures = true
 

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
@@ -33,7 +33,9 @@ class LicensePluginTest {
     @Before
     public void setupProject() {
         project = ProjectBuilder.builder().withProjectDir(new File("testProject")).build()
-        project.apply plugin: 'license'
+        def plugin = project.plugins.apply(LicensePlugin)
+        plugin.configureSourceSetRule()
+
     }
 
     @Test

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/LicenseTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/LicenseTest.groovy
@@ -29,7 +29,9 @@ class LicenseTest {
     public void setupProject() {
         project = ProjectBuilder.builder().withProjectDir(new File("testProject")).build()
         project.apply plugin: 'java'
-        project.apply plugin: 'license'
+        def plugin = project.plugins.apply(LicensePlugin)
+        plugin.configureSourceSetRule()
+
     }
 
     @Test


### PR DESCRIPTION
The project was not respecting sourceSets being set on the extension, because of the timing of the extension.sourceSets call.  We need to run in afterEvaluate, so that the user has a chance to set it first. It was feasible for them to configure the license extension, the apply the java or androind plugins, but that's too fragile to rely on.