### PR TITLE
support wild card excludes

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -124,7 +124,7 @@ class LicenseResolver {
             def runtimeConfiguration = project.configurations.getByName(dependencyConfiguration)
             runtimeConfiguration.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact d ->
                 String dependencyDesc = "$d.moduleVersion.id.group:$d.moduleVersion.id.name:$d.moduleVersion.id.version".toString()
-                if(!dependenciesToIgnore.contains(dependencyDesc)) {
+                if(!matchExcludedDependency(dependencyDesc)) {
                     Project subproject = subprojects[dependencyDesc]?.first()
                     if (subproject) {
                         if(includeProjectDependencies) {
@@ -222,5 +222,23 @@ class LicenseResolver {
         } else {
             noLicenseMetaData(dependencyDesc)
         }
+    }
+
+    private boolean matchExcludedDependency(String dependencyDesc) {
+       if (dependenciesToIgnore.contains(dependencyDesc)) {
+           return true;
+       } else {
+           for (String exclude : dependenciesToIgnore) {
+              if (exclude.endsWith("+")) {
+                 int excludeLength = exclude.length() - 1;
+                 if (dependencyDesc.substring(0, excludeLength).equals(exclude.substring(0, excludeLength))) {
+                    return true;
+                 }
+              }
+           }
+       }
+
+       return false;
+
     }
 }

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/DownloadLicensesIntegTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/DownloadLicensesIntegTest.groovy
@@ -538,6 +538,31 @@ class DownloadLicensesIntegTest extends Specification {
         dependencyWithLicensePresent(xmlByDependency, "dep3.jar", "dep3.jar", "No license found")
     }
 
+    def "Test that we can exclude with dynamic version"() {
+       setup:
+       project.dependencies {
+          compile 'com.google.guava:guava:15.0'
+          compile 'com.sun.mail:javax.mail:1.5.+'
+       }
+
+       project.downloadLicenses {
+          excludeDependencies = ["com.google.guava:guava:+", "com.sun.mail:javax.mail:1.5.+"]
+       }
+
+       when:
+       downloadLicenses.execute()
+
+       then:
+       File f = getLicenseReportFolder()
+       assertLicenseReportsExist(f)
+
+       def xmlByDependency = xml4LicenseByDependencyReport(f)
+       def xmlByLicense = xml4DependencyByLicenseReport(f)
+
+       dependenciesInReport(xmlByDependency) == 1
+       licensesInReport(xmlByLicense) == 1
+    }
+
     def "Test that we can exclude particular external dependencies from report"() {
         setup:
         project.dependencies {


### PR DESCRIPTION
Add support for wild card excludes. This should behave mostly like the + operator in dependency configuration.

This fixes part of #52 but does not try to deal with groups.

If you can think of a better way to solve this I would like to hear it, this feels a bit crude. However it solves our problem.
