### PR TITLE
Add missing apply statements to README examples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,6 +36,8 @@ In your `build.gradle` file add:
             classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:{license_plugin_version}'
         }
     }
+
+    apply plugin: 'license'
 ----
 
 === Gradle 1.x/2.0, gradle-license-plugin 0.10.0 (and earlier)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ In your _build.gradle_ file add:
             classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
         }
     }
+
+    apply plugin: 'license'
 ```
 
 ### Gradle 1.x/2.0, gradle-license-plugin 0.10.0 (and earlier)


### PR DESCRIPTION
We still need the "apply plugin" statement with the latest plugin version when using Gradle 1.x / 2.0.