### PR TITLE
Android source sets configured for LibraryPlugin

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
@@ -17,6 +17,7 @@
 
 package nl.javadude.gradle.plugins.license
 
+import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.AndroidSourceSet
 import com.android.build.gradle.AppPlugin
 import org.gradle.api.Action
@@ -67,7 +68,11 @@ class LicensePlugin implements Plugin<Project> {
             }
 
             withOptionalPlugin('com.android.build.gradle.AppPlugin') {
-                configureAndroid()
+                configureAndroid(AppPlugin)
+            }
+
+            withOptionalPlugin('com.android.build.gradle.LibraryPlugin') {
+                configureAndroid(LibraryPlugin)
             }
         }
 
@@ -259,20 +264,20 @@ class LicensePlugin implements Plugin<Project> {
         task.source = sourceSet.allSource
     }
 
-    private void configureAndroid() {
-        configureExtensionRule(AppPlugin)
+    private void configureAndroid(Class pluginType) {
+        configureExtensionRule(pluginType)
         project.afterEvaluate {
             // Since we're going to look at the extension, we need to run late enough to let the user configure it
-            configureAndroidSourceSetRule()
+            configureAndroidSourceSetRule(pluginType)
         }
     }
 
     /**
      * Dynamically create a task for each sourceSet, and register with check
      */
-    private void configureAndroidSourceSetRule() {
+    private void configureAndroidSourceSetRule(Class pluginType) {
         // This follows the other check task pattern
-        project.plugins.withType(AppPlugin) {
+        project.plugins.withType(pluginType) {
             extension.sourceSets.all { AndroidSourceSet sourceSet ->
                 def sourceSetTaskName = (taskBaseName + 'Android' + sourceSet.name.capitalize())
                 logger.info("[AndroidLicensePlugin] Adding license tasks for sourceSet ${sourceSetTaskName}");

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/AndroidLicensePluginTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/AndroidLicensePluginTest.groovy
@@ -17,6 +17,7 @@
 
 package nl.javadude.gradle.plugins.license
 
+import com.android.build.gradle.AppPlugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
@@ -37,7 +38,7 @@ class AndroidLicensePluginTest {
         project.apply plugin: 'com.android.application'
 
         // Otherwise we'd need a project.evaluate() which would trigger Android SDK detection
-        plugin.configureAndroidSourceSetRule()
+        plugin.configureAndroidSourceSetRule(AppPlugin)
     }
 
     @Test

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/AndroidLicensePluginTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/AndroidLicensePluginTest.groovy
@@ -18,27 +18,47 @@
 package nl.javadude.gradle.plugins.license
 
 import com.android.build.gradle.AppPlugin
+import com.android.build.gradle.LibraryPlugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
 import static org.hamcrest.CoreMatchers.*
-import static org.junit.Assert.assertThat
 import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertThat
 
+@RunWith(Parameterized.class)
 class AndroidLicensePluginTest {
     Project project
+    String pluginName
+    Class pluginClass
+
+    @Parameterized.Parameters(name =  "Plugin {0}")
+    public static Collection<Object[]> pluginTypes() {
+        Object[][] params = [
+            [ 'com.android.application', AppPlugin ],
+            [ 'com.android.library', LibraryPlugin ]
+        ];
+        return Arrays.asList(params);
+    }
+
+    public AndroidLicensePluginTest(pluginName, pluginClass) {
+        this.pluginName = pluginName
+        this.pluginClass = pluginClass
+    }
 
     @Before
     public void setupProject() {
         project = ProjectBuilder.builder().withProjectDir(new File("testProject")).build()
         def plugin = project.plugins.apply(LicensePlugin)
-        project.apply plugin: 'com.android.application'
+        project.apply plugin: pluginName
 
         // Otherwise we'd need a project.evaluate() which would trigger Android SDK detection
-        plugin.configureAndroidSourceSetRule(AppPlugin)
+        plugin.configureAndroidSourceSetRule(pluginClass)
     }
 
     @Test


### PR DESCRIPTION
Hi there!
We wanted to use the plugin for our Android libraries, but we noted that the task `license` was always `UP-TO-DATE` no matter how we configured the extension.  We realized that no source of any kind was "passed" to the plugin. Thats when we noticed that the plugin configures android source sets for `AppPlugin` types only. So, we added android source sets configuration of `LibraryPlugin` as well.
