### PR TITLE
Changed the type of sourceSets to something that will actually work

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseExtension.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseExtension.groovy
@@ -17,7 +17,7 @@
 
 package nl.javadude.gradle.plugins.license
 
-import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
 
 /**
  * Extension in the license namespace, which drives the License tasks.
@@ -38,7 +38,7 @@ class LicenseExtension {
     /**
      * Source sets to perform search on, will default to all sourceSets in the project
      */
-    Collection<SourceSet> sourceSets // Probably should be final SourceSetContainer, so that it doesn't turn out null at anytime
+    SourceSetContainer sourceSets
 
     /**
      * Path patterns to exclude while applying licenses or reporting missing licenses

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
@@ -103,9 +103,6 @@ class LicensePlugin implements Plugin<Project> {
             useDefaultMappings = true
             strictCheck = false
             encoding = System.properties['file.encoding']
-            conventionMapping.with {
-                sourceSets = { [] }
-            }
         }
         
 

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
@@ -74,8 +74,7 @@ class LicensePluginTest {
 
     @Test
     public void extensionShouldNotHaveSourceSets() {
-        assertThat project.license.sourceSets, is(notNullValue())
-        assertThat project.license.sourceSets.size(), equalTo(0)
+        assertThat project.license.sourceSets, is(nullValue())
     }
 
     @Test


### PR DESCRIPTION
The prior type of collection doesn't work. If you pass it a collection it fails when it tries to call all on the collection in `LicensePlugin`. It really needs to be a `SourceSetContainer`. Unfortunately, the gradle API doesn't expose any concrete implementations of `SourceSetContainer`, so i can't set the default to an empty one like was happening before. I decided that leaving it null was unfortunately the lesser of two evils. This isn't as bad as it seems because in real usage it'll never be null at runtime.
