### PR TITLE
Use Gradle 2.12's new compileOnly configuration for the Android plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: "com.gradle.plugin-publish"
 apply plugin: 'license'
-apply plugin: 'optional-base'
 
 buildscript {
     repositories {
@@ -53,8 +52,11 @@ dependencies {
         exclude group: 'org.apache.maven', module: 'maven-plugin-api'
         exclude group: 'org.apache.maven', module: 'maven-project'
     }
-    compile 'com.android.tools.build:gradle:2.0.+', optional
     compile gradleApi()
+
+    def androidGradlePlugin = 'com.android.tools.build:gradle:2.0.+'
+    compileOnly androidGradlePlugin
+    testCompile androidGradlePlugin
 
     testCompile 'junit:junit:4.11'
     testCompile 'com.google.guava:guava:17.0'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,8 +13,9 @@ dependencies {
         exclude group: 'org.apache.maven', module: 'maven-plugin-api'
         exclude group: 'org.apache.maven', module: 'maven-project'
     }
-    compile 'com.android.tools.build:gradle:1.0.+'
     compile gradleApi()
+
+    compileOnly 'com.android.tools.build:gradle:2.0.+'
 }
 
 sourceSets {

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -8,7 +8,6 @@ import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import org.gradle.api.tasks.TaskExecutionException
 
 import static DependencyMetadata.noLicenseMetaData
 
@@ -217,7 +216,7 @@ class LicenseResolver {
             if (ignoreFatalParseErrors) {
                 return noLicenseMetaData(dependencyDesc)
             } else {
-                throw new TaskExecutionException(e.getMessage())
+                throw e
             }
         }
 


### PR DESCRIPTION
Do not break projects that use the plugin and depend on an older version of
the Android Gradle plugin by not exposing this dependency at runtime.