### PR TITLE
Swapped Collection.all {} for Collection.each {}

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
@@ -283,7 +283,7 @@ class LicensePlugin implements Plugin<Project> {
     private void configureAndroidSourceSetRule(Class pluginType) {
         // This follows the other check task pattern
         project.plugins.withType(pluginType) {
-            extension.sourceSets.all { sourceSet ->
+            extension.sourceSets.each { sourceSet ->
                 def sourceSetTaskName = "${taskBaseName}Android${sourceSet.name.capitalize()}"
                 logger.info("[AndroidLicensePlugin] Adding license tasks for sourceSet ${sourceSetTaskName}");
 


### PR DESCRIPTION
From my testing trying to use this plugin with gradle 3.0:
No signature of method: java.util.ArrayList.all() is applicable for argument types: (nl.javadude.gradle.plugins.license.LicensePlugin$_configureSourceSetRule_closure10$_closure48)