### PR TITLE
Add ability to add custom header definitions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -207,18 +207,6 @@ so the ability to specify your own is beneficial.
 
 Adding a new header definition is done through the licence extension
 
-
- String type
-  String firstLine
-  String beforeEachLine
-  String endLine
-  boolean allowBlankLines = false
-
-  String skipLinePattern
-  String firstLineDetectionPattern
-  String lastLineDetectionPattern
-  boolean isMultiline = false
-
 [source,groovy]
 ----
 license {

--- a/README.adoc
+++ b/README.adoc
@@ -119,6 +119,8 @@ Here is a general overview of the options:
 |excludes(Collection<String> patterns) |Add ANT style patterns to exclude files from license absence reporting and license application
 |include(String pattern) |Add an ANT style pattern to include files into license absence reporting and license application
 |includes(Collection<String> patterns) |Add ANT style patterns to include files into license absence reporting and license application
+|headerDefinition(HeaderDefinitionBuilder headerDefinition) |Add a custom header definition that will be added to the defaults.
+|headerDefinitions(Closure) | Add a custom header definition that will be added to the defaults.
 |====
 
 === Header Locations
@@ -197,6 +199,41 @@ license {
 }
 // or
 licenseMain.ext.year = 2012
+----
+
+=== Creating your own header definition
+In some cases the default header definitions can not be used for a specific project
+so the ability to specify your own is beneficial.
+
+Adding a new header definition is done through the licence extension
+
+
+ String type
+  String firstLine
+  String beforeEachLine
+  String endLine
+  boolean allowBlankLines = false
+
+  String skipLinePattern
+  String firstLineDetectionPattern
+  String lastLineDetectionPattern
+  boolean isMultiline = false
+
+[source,groovy]
+----
+license {
+    headerDefinitions {
+        custom_definition {
+          firstLine = "//"
+          endLine   = "//"
+          firstLineDetectionPattern = "//"
+          lastLineDetectionPattern  = "//"
+          allowBlankLines = false
+          skipLinePattern = "//"
+          isMultiline = false
+        }
+    }
+}
 ----
 
 === Include/Exclude files from license absence reporting and license application

--- a/README.adoc
+++ b/README.adoc
@@ -205,7 +205,7 @@ licenseMain.ext.year = 2012
 In some cases the default header definitions can not be used for a specific project
 so the ability to specify your own is beneficial.
 
-Adding a new header definition is done through the licence extension
+Adding a new header definition is done through the license extension
 
 [source,groovy]
 ----

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
@@ -169,8 +169,7 @@ public class License extends SourceTask implements VerificationTask {
         return combinedMappings
     }
 
-    List<HeaderDefinition> buildHeaderDefinitions()
-    {
+    List<HeaderDefinition> buildHeaderDefinitions() {
         List<HeaderDefinition> definitions = new ArrayList<>();
         getHeaderDefinitions().all { headerDefinition ->
             logger.debug("Adding extra header definition ${headerDefinition.toString()}")

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
@@ -17,14 +17,16 @@
 
 package nl.javadude.gradle.plugins.license
 
+import com.google.code.mojo.license.header.HeaderDefinition
+import nl.javadude.gradle.plugins.license.header.HeaderDefinitionBuilder
 import nl.javadude.gradle.plugins.license.maven.AbstractLicenseMojo
 import nl.javadude.gradle.plugins.license.maven.CallbackWithFailure
 import nl.javadude.gradle.plugins.license.maven.LicenseCheckMojo
 import nl.javadude.gradle.plugins.license.maven.LicenseFormatMojo
 import org.gradle.api.GradleException
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.*
-
 /**
  * Task to back License. Using convention of naming Task types with just their name, which makes calls
  * like tasks.withType(License) nicer, consistent with most internal Gradle tasks.
@@ -73,7 +75,7 @@ public class License extends SourceTask implements VerificationTask {
     File header
 
     /**
-     * In leiu of a header file on the local filesystem, this property lets you provide a URL that could be
+     * In lieu of a header file on the local filesystem, this property lets you provide a URL that could be
      * in the classpath or on a remote system. When configured across a few projects, it would mean that a
      * header file doesn't have to be in each project.
      */
@@ -89,6 +91,9 @@ public class License extends SourceTask implements VerificationTask {
 
     Map<String, String> inheritedProperties;
     Map<String, String> inheritedMappings;
+
+    // Container for all custom header definitions
+    NamedDomainObjectContainer<HeaderDefinitionBuilder> headerDefinitions;
 
     @TaskAction
     protected void process() {
@@ -112,7 +117,7 @@ public class License extends SourceTask implements VerificationTask {
 
         URI uri = getURI()
 
-        new AbstractLicenseMojo(validHeaders, getProject().rootDir, initial, isDryRun(), isSkipExistingHeaders(), isUseDefaultMappings(), isStrictCheck(), uri, source, combinedMappings, getEncoding())
+        new AbstractLicenseMojo(validHeaders, getProject().rootDir, initial, isDryRun(), isSkipExistingHeaders(), isUseDefaultMappings(), isStrictCheck(), uri, source, combinedMappings, getEncoding(), buildHeaderDefinitions())
             .execute(callback);
 
         altered = callback.getAffected()
@@ -162,6 +167,17 @@ public class License extends SourceTask implements VerificationTask {
         }
         combinedMappings.putAll(internalMappings)
         return combinedMappings
+    }
+
+    List<HeaderDefinition> buildHeaderDefinitions()
+    {
+        List<HeaderDefinition> definitions = new ArrayList<>();
+        getHeaderDefinitions().all { headerDefinition ->
+            logger.debug("Adding extra header definition ${headerDefinition.toString()}")
+            definitions.add(headerDefinition.build())
+        }
+
+        return definitions
     }
 
     Map<String, String> internalMappings = new HashMap<String, String>();

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseExtension.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseExtension.groovy
@@ -17,9 +17,10 @@
 
 package nl.javadude.gradle.plugins.license
 
+import nl.javadude.gradle.plugins.license.header.HeaderDefinitionBuilder
 import org.gradle.api.DomainObjectCollection
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.tasks.SourceSet
-
 /**
  * Extension in the license namespace, which drives the License tasks.
  *
@@ -75,6 +76,11 @@ class LicenseExtension {
     boolean strictCheck
 
     /**
+     * Additional header definitions
+     */
+    NamedDomainObjectContainer<HeaderDefinitionBuilder> headerDefinitions
+
+    /**
      * The encoding used for opening files. It is the system encoding by default
      */
     String encoding
@@ -112,4 +118,11 @@ class LicenseExtension {
       includePatterns.addAll(patterns)
     }
 
+    def headerDefinitions(final Closure configureHeaderDefinition) {
+      headerDefinitions.configure(configureHeaderDefinition);
+    }
+
+    void headerDefinition(HeaderDefinitionBuilder definition) {
+      headerDefinitions.add(definition);
+    }
 }

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
@@ -17,11 +17,8 @@
 
 package nl.javadude.gradle.plugins.license
 
-import org.gradle.api.Action
-import org.gradle.api.DomainObjectCollection
-import org.gradle.api.Plugin
-import org.gradle.api.Project
-import org.gradle.api.Task
+import nl.javadude.gradle.plugins.license.header.HeaderDefinitionBuilder
+import org.gradle.api.*
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.JavaBasePlugin
@@ -107,6 +104,7 @@ class LicensePlugin implements Plugin<Project> {
             conventionMapping.with {
                 sourceSets = { [] as DomainObjectCollection<SourceSet> }
             }
+            headerDefinitions = project.container(HeaderDefinitionBuilder)
         }
 
 
@@ -217,6 +215,7 @@ class LicensePlugin implements Plugin<Project> {
             excludes = { extension.excludePatterns }
             includes = { extension.includePatterns }
             encoding = { extension.encoding }
+            headerDefinitions = { extension.headerDefinitions }
         }
     }
 

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicensePlugin.groovy
@@ -18,7 +18,11 @@
 package nl.javadude.gradle.plugins.license
 
 import nl.javadude.gradle.plugins.license.header.HeaderDefinitionBuilder
-import org.gradle.api.*
+import org.gradle.api.Action
+import org.gradle.api.DomainObjectCollection
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.JavaBasePlugin

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/header/HeaderDefinitionBuilder.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/header/HeaderDefinitionBuilder.groovy
@@ -3,8 +3,7 @@ package nl.javadude.gradle.plugins.license.header
 import com.google.code.mojo.license.header.HeaderDefinition
 import org.gradle.api.Named
 
-class HeaderDefinitionBuilder implements Named
-{
+class HeaderDefinitionBuilder implements Named {
   String type
   String firstLine
   String beforeEachLine
@@ -16,78 +15,65 @@ class HeaderDefinitionBuilder implements Named
   String lastLineDetectionPattern
   boolean isMultiline = false
 
-  static HeaderDefinitionBuilder headerDefinition(String name)
-  {
+  static HeaderDefinitionBuilder headerDefinition(String name) {
     return new HeaderDefinitionBuilder(name)
   }
 
-  HeaderDefinitionBuilder(String type)
-  {
+  HeaderDefinitionBuilder(String type) {
     this.type = type
   }
 
-  HeaderDefinitionBuilder withFirstLine(String firstLine)
-  {
+  HeaderDefinitionBuilder withFirstLine(String firstLine) {
     this.firstLine = firstLine
     return this
   }
 
-  HeaderDefinitionBuilder withBeforeEachLine(String beforeEachLine)
-  {
+  HeaderDefinitionBuilder withBeforeEachLine(String beforeEachLine) {
     this.beforeEachLine = beforeEachLine
     return this
   }
 
-  HeaderDefinitionBuilder withEndLine(String endLine)
-  {
+  HeaderDefinitionBuilder withEndLine(String endLine) {
     this.endLine = endLine
     return this
   }
 
-  HeaderDefinitionBuilder withNoBlankLines()
-  {
+  HeaderDefinitionBuilder withNoBlankLines() {
     this.allowBlankLines = false
     return this
   }
 
-  HeaderDefinitionBuilder withBlankLines()
-  {
+  HeaderDefinitionBuilder withBlankLines() {
     this.allowBlankLines = true
     return this
   }
 
-  HeaderDefinitionBuilder withSkipLinePattern(String skipLinePattern)
-  {
+  HeaderDefinitionBuilder withSkipLinePattern(String skipLinePattern) {
     this.skipLinePattern = skipLinePattern
     return this
   }
 
-  HeaderDefinitionBuilder withFirstLineDetectionDetectionPattern(String firstLineDetectionPattern)
-  {
+  HeaderDefinitionBuilder withFirstLineDetectionDetectionPattern(String firstLineDetectionPattern) {
     this.firstLineDetectionPattern = firstLineDetectionPattern
     return this
   }
 
-  HeaderDefinitionBuilder withLastLineDetectionDetectionPattern(String lastLineDetectionPattern)
-  {
+  HeaderDefinitionBuilder withLastLineDetectionDetectionPattern(String lastLineDetectionPattern) {
     this.lastLineDetectionPattern = lastLineDetectionPattern
     return this
   }
 
-  HeaderDefinitionBuilder multiline()
-  {
+  HeaderDefinitionBuilder multiline() {
     this.isMultiline = true
     return this
   }
 
-  HeaderDefinitionBuilder noMultiLine()
-  {
+  HeaderDefinitionBuilder noMultiLine() {
     this.isMultiline = false
     return this
   }
 
-  HeaderDefinition build()
-  {
+  HeaderDefinition build() {
     return new HeaderDefinition(type,
       firstLine,
       beforeEachLine,
@@ -100,8 +86,7 @@ class HeaderDefinitionBuilder implements Named
   }
 
   @Override
-  String toString()
-  {
+  String toString() {
     return "{" +
       "type='" + type + '\'' +
       ", firstLine='" + firstLine + '\'' +
@@ -116,8 +101,7 @@ class HeaderDefinitionBuilder implements Named
   }
 
   @Override
-  String getName()
-  {
+  String getName() {
     return type
   }
 }

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/header/HeaderDefinitionBuilder.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/header/HeaderDefinitionBuilder.groovy
@@ -1,0 +1,123 @@
+package nl.javadude.gradle.plugins.license.header
+
+import com.google.code.mojo.license.header.HeaderDefinition
+import org.gradle.api.Named
+
+class HeaderDefinitionBuilder implements Named
+{
+  String type
+  String firstLine
+  String beforeEachLine
+  String endLine
+  boolean allowBlankLines = false
+
+  String skipLinePattern
+  String firstLineDetectionPattern
+  String lastLineDetectionPattern
+  boolean isMultiline = false
+
+  static HeaderDefinitionBuilder headerDefinition(String name)
+  {
+    return new HeaderDefinitionBuilder(name)
+  }
+
+  HeaderDefinitionBuilder(String type)
+  {
+    this.type = type
+  }
+
+  HeaderDefinitionBuilder withFirstLine(String firstLine)
+  {
+    this.firstLine = firstLine
+    return this
+  }
+
+  HeaderDefinitionBuilder withBeforeEachLine(String beforeEachLine)
+  {
+    this.beforeEachLine = beforeEachLine
+    return this
+  }
+
+  HeaderDefinitionBuilder withEndLine(String endLine)
+  {
+    this.endLine = endLine
+    return this
+  }
+
+  HeaderDefinitionBuilder withNoBlankLines()
+  {
+    this.allowBlankLines = false
+    return this
+  }
+
+  HeaderDefinitionBuilder withBlankLines()
+  {
+    this.allowBlankLines = true
+    return this
+  }
+
+  HeaderDefinitionBuilder withSkipLinePattern(String skipLinePattern)
+  {
+    this.skipLinePattern = skipLinePattern
+    return this
+  }
+
+  HeaderDefinitionBuilder withFirstLineDetectionDetectionPattern(String firstLineDetectionPattern)
+  {
+    this.firstLineDetectionPattern = firstLineDetectionPattern
+    return this
+  }
+
+  HeaderDefinitionBuilder withLastLineDetectionDetectionPattern(String lastLineDetectionPattern)
+  {
+    this.lastLineDetectionPattern = lastLineDetectionPattern
+    return this
+  }
+
+  HeaderDefinitionBuilder multiline()
+  {
+    this.isMultiline = true
+    return this
+  }
+
+  HeaderDefinitionBuilder noMultiLine()
+  {
+    this.isMultiline = false
+    return this
+  }
+
+  HeaderDefinition build()
+  {
+    return new HeaderDefinition(type,
+      firstLine,
+      beforeEachLine,
+      endLine,
+      skipLinePattern,
+      firstLineDetectionPattern,
+      lastLineDetectionPattern,
+      allowBlankLines,
+      isMultiline)
+  }
+
+  @Override
+  String toString()
+  {
+    return "{" +
+      "type='" + type + '\'' +
+      ", firstLine='" + firstLine + '\'' +
+      ", beforeEachLine='" + beforeEachLine + '\'' +
+      ", endLine='" + endLine + '\'' +
+      ", allowBlankLines=" + allowBlankLines +
+      ", skipLinePattern='" + skipLinePattern + '\'' +
+      ", firstLineDetectionPattern='" + firstLineDetectionPattern + '\'' +
+      ", lastLineDetectionPattern='" + lastLineDetectionPattern + '\'' +
+      ", isMultiline=" + isMultiline +
+      '}'
+  }
+
+  @Override
+  String getName()
+  {
+    return type
+  }
+}

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/LicenseIntegTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/LicenseIntegTest.groovy
@@ -19,6 +19,7 @@ package nl.javadude.gradle.plugins.license
 
 import com.google.common.collect.Iterables
 import com.google.common.io.Files
+import nl.javadude.gradle.plugins.license.header.HeaderDefinitionBuilder
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.After
@@ -213,6 +214,35 @@ key2 = value2
         def expected = '''/**
  * This is a sample license created in ${year}
  */
+public class Test {
+        static { System.out.println("Hello") }
+}
+'''
+        assert javaFile.getText().equals(expected);
+    }
+
+
+    @Test
+    public void canApplyCustomHeaderDefinitionFormatting() {
+        File javaFile = createJavaFile()
+
+        HeaderDefinitionBuilder customDefinition = HeaderDefinitionBuilder.headerDefinition("custom")
+            .withFirstLine("// custom start")
+            .withEndLine("// custom end")
+            .withBeforeEachLine("// ")
+            .withFirstLineDetectionDetectionPattern("//")
+            .withLastLineDetectionDetectionPattern("//")
+
+        licenseFormatTask.headerDefinitions.add customDefinition
+        licenseFormatTask.mapping("java", "custom")
+
+        licenseFormatTask.execute()
+
+        assert licenseFormatTask.altered.size()  == 1
+        assert Iterables.get(licenseFormatTask.altered, 0).equals(javaFile)
+        def expected = '''// custom start
+// This is a sample license created in ${year}
+// custom end
 public class Test {
         static { System.out.println("Hello") }
 }

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/LicenseIntegTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/LicenseIntegTest.groovy
@@ -225,24 +225,29 @@ public class Test {
     @Test
     public void canApplyCustomHeaderDefinitionFormatting() {
         File javaFile = createJavaFile()
-
-        HeaderDefinitionBuilder customDefinition = HeaderDefinitionBuilder.headerDefinition("custom")
-            .withFirstLine("// custom start")
-            .withEndLine("// custom end")
-            .withBeforeEachLine("// ")
-            .withFirstLineDetectionDetectionPattern("//")
-            .withLastLineDetectionDetectionPattern("//")
+        createLicenseFile '''Put a gun against his head,
+Pulled my trigger, now he's dead.
+Mama, life had just begun,
+'''
+        HeaderDefinitionBuilder customDefinition = HeaderDefinitionBuilder.headerDefinition("bohemian_rhapsody")
+            .withFirstLine("Mama, just killed a man,")
+            .withEndLine("But now I've gone and thrown it all away.")
+            .withBeforeEachLine(" ")
+            .withFirstLineDetectionDetectionPattern("Mama")
+            .withLastLineDetectionDetectionPattern("away")
 
         licenseFormatTask.headerDefinitions.add customDefinition
-        licenseFormatTask.mapping("java", "custom")
+        licenseFormatTask.mapping("java", "bohemian_rhapsody")
 
         licenseFormatTask.execute()
 
         assert licenseFormatTask.altered.size()  == 1
         assert Iterables.get(licenseFormatTask.altered, 0).equals(javaFile)
-        def expected = '''// custom start
-// This is a sample license created in ${year}
-// custom end
+        def expected = '''Mama, just killed a man,
+ Put a gun against his head,
+ Pulled my trigger, now he's dead.
+ Mama, life had just begun,
+But now I've gone and thrown it all away.
 public class Test {
         static { System.out.println("Hello") }
 }
@@ -302,12 +307,15 @@ key2 = value2
         propFile.text.startsWith("# It’s mine, I tell you, mine!")
     }
 
-    public File createLicenseFile() {
+    public File createLicenseFile(String content) {
         File file = project.file("LICENSE")
         Files.createParentDirs(file);
-        file << '''This is a sample license created in ${year}
-'''
+        file.text = content
         file
+    }
+
+    public File createLicenseFile() {
+        createLicenseFile '''This is a sample license created in ${year}'''
     }
 
     public File createJavaFile() {

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
@@ -17,6 +17,7 @@
 
 package nl.javadude.gradle.plugins.license
 
+import nl.javadude.gradle.plugins.license.header.HeaderDefinitionBuilder
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
@@ -167,6 +168,37 @@ class LicensePluginTest {
         def mappings = task.combinedMappings()
         assert mappings.containsKey('map1')
         assert mappings.containsKey('map2')
+    }
+
+    @Test
+    void canAddExtraHeaderDefinition()
+    {
+        HeaderDefinitionBuilder headerDefinitionBuilder = HeaderDefinitionBuilder.headerDefinition("custom_definition")
+        project.license {
+            headerDefinition headerDefinitionBuilder
+        }
+
+        LicenseExtension extension = project.extensions.getByType(LicenseExtension)
+
+        assertThat(extension.headerDefinitions.isEmpty(), is(false))
+        assertThat(extension.headerDefinitions.size(), is(1))
+        assertThat(extension.headerDefinitions.getByName("custom_definition"), is(headerDefinitionBuilder))
+    }
+
+    @Test
+    void canAddMultipleHeaderDefinitions()
+    {
+        project.license {
+            headerDefinition HeaderDefinitionBuilder.headerDefinition("some_style")
+            headerDefinition HeaderDefinitionBuilder.headerDefinition("some_other_style")
+        }
+
+        LicenseExtension extension = project.extensions.getByType(LicenseExtension)
+
+        assertThat(extension.headerDefinitions.isEmpty(), is(false))
+        assertThat(extension.headerDefinitions.size(), is(2))
+        assertThat(extension.headerDefinitions.getByName("some_style"), is(notNullValue()))
+        assertThat(extension.headerDefinitions.getByName("some_other_style"), is(notNullValue()))
     }
 }
 

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/header/HeaderDefinitionBuilderTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/header/HeaderDefinitionBuilderTest.groovy
@@ -7,8 +7,8 @@ import org.junit.rules.ExpectedException
 import static org.hamcrest.CoreMatchers.is
 import static org.junit.Assert.assertThat
 
-class HeaderDefinitionBuilderTest
-{
+class HeaderDefinitionBuilderTest {
+
   @Rule
   public ExpectedException expectedException = ExpectedException.none()
 
@@ -23,77 +23,65 @@ class HeaderDefinitionBuilderTest
     .withBlankLines()
 
   @Test
-  void setsType()
-  {
+  void setsType() {
     assertThat builder.build().type, is("freddie")
   }
 
   @Test
-  void setsFirstLine()
-  {
+  void setsFirstLine() {
     assertThat builder.build().firstLine, is("5 September 1946")
   }
 
   @Test
-  void setsEndLine()
-  {
+  void setsEndLine() {
     assertThat builder.build().endLine, is("24 November 1991")
   }
 
   @Test
-  void setsBeforeEachLine()
-  {
+  void setsBeforeEachLine() {
     assertThat builder.build().beforeEachLine, is("Rock")
   }
 
   @Test
-  void setsFirstLineDetectionPattern()
-  {
+  void setsFirstLineDetectionPattern() {
     assertThat builder.build().isFirstHeaderLine("First day"), is(true)
   }
 
   @Test
-  void setsLastLineDetectionPattern()
-  {
+  void setsLastLineDetectionPattern() {
     assertThat builder.build().isLastHeaderLine("Last day"), is(true)
   }
 
   @Test
-  void setsMultiline()
-  {
+  void setsMultiline() {
     assertThat builder.build().isMultiLine(), is(true)
   }
 
   @Test
-  void disablesMultiline()
-  {
+  void disablesMultiline() {
     builder.noMultiLine()
 
     assertThat builder.build().isMultiLine(), is(false)
   }
 
   @Test
-  void allowsBlankLines()
-  {
+  void allowsBlankLines() {
     assertThat builder.build().allowBlankLines(), is(true)
   }
 
   @Test
-  void noBlankLines()
-  {
+  void noBlankLines() {
     builder.withNoBlankLines()
     assertThat builder.build().allowBlankLines(), is(false)
   }
 
   @Test
-  void setsSkipLines()
-  {
+  void setsSkipLines() {
     assertThat builder.build().isSkipLine("HIV"), is(true)
   }
 
   @Test
-  void validatesOnBuild()
-  {
+  void validatesOnBuild() {
     expectedException.expect(IllegalStateException)
     expectedException.expectMessage("missing for header definition")
 

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/header/HeaderDefinitionBuilderTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/header/HeaderDefinitionBuilderTest.groovy
@@ -1,10 +1,10 @@
 package nl.javadude.gradle.plugins.license.header
 
-import org.hamcrest.CoreMatchers
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 
+import static org.hamcrest.CoreMatchers.is
 import static org.junit.Assert.assertThat
 
 class HeaderDefinitionBuilderTest
@@ -25,43 +25,43 @@ class HeaderDefinitionBuilderTest
   @Test
   void setsType()
   {
-    assertThat builder.build().type, CoreMatchers.is("freddie")
+    assertThat builder.build().type, is("freddie")
   }
 
   @Test
   void setsFirstLine()
   {
-    assertThat builder.build().firstLine, CoreMatchers.is("5 September 1946")
+    assertThat builder.build().firstLine, is("5 September 1946")
   }
 
   @Test
   void setsEndLine()
   {
-    assertThat builder.build().endLine, CoreMatchers.is("24 November 1991")
+    assertThat builder.build().endLine, is("24 November 1991")
   }
 
   @Test
   void setsBeforeEachLine()
   {
-    assertThat builder.build().beforeEachLine, CoreMatchers.is("Rock")
+    assertThat builder.build().beforeEachLine, is("Rock")
   }
 
   @Test
   void setsFirstLineDetectionPattern()
   {
-    assertThat builder.build().isFirstHeaderLine("First day"), CoreMatchers.is(true)
+    assertThat builder.build().isFirstHeaderLine("First day"), is(true)
   }
 
   @Test
   void setsLastLineDetectionPattern()
   {
-    assertThat builder.build().isLastHeaderLine("Last day"), CoreMatchers.is(true)
+    assertThat builder.build().isLastHeaderLine("Last day"), is(true)
   }
 
   @Test
   void setsMultiline()
   {
-    assertThat builder.build().isMultiLine(), CoreMatchers.is(true)
+    assertThat builder.build().isMultiLine(), is(true)
   }
 
   @Test
@@ -69,26 +69,26 @@ class HeaderDefinitionBuilderTest
   {
     builder.noMultiLine()
 
-    assertThat builder.build().isMultiLine(), CoreMatchers.is(false)
+    assertThat builder.build().isMultiLine(), is(false)
   }
 
   @Test
   void allowsBlankLines()
   {
-    assertThat builder.build().allowBlankLines(), CoreMatchers.is(true)
+    assertThat builder.build().allowBlankLines(), is(true)
   }
 
   @Test
   void noBlankLines()
   {
     builder.withNoBlankLines()
-    assertThat builder.build().allowBlankLines(), CoreMatchers.is(false)
+    assertThat builder.build().allowBlankLines(), is(false)
   }
 
   @Test
   void setsSkipLines()
   {
-    assertThat builder.build().isSkipLine("HIV"), CoreMatchers.is(true)
+    assertThat builder.build().isSkipLine("HIV"), is(true)
   }
 
   @Test

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/header/HeaderDefinitionBuilderTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/header/HeaderDefinitionBuilderTest.groovy
@@ -1,0 +1,102 @@
+package nl.javadude.gradle.plugins.license.header
+
+import org.hamcrest.CoreMatchers
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+
+import static org.junit.Assert.assertThat
+
+class HeaderDefinitionBuilderTest
+{
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none()
+
+  HeaderDefinitionBuilder builder = HeaderDefinitionBuilder.headerDefinition("freddie")
+    .withFirstLine("5 September 1946")
+    .withBeforeEachLine("Rock")
+    .withEndLine("24 November 1991")
+    .withFirstLineDetectionDetectionPattern("First day")
+    .withLastLineDetectionDetectionPattern("Last day")
+    .withSkipLinePattern("HIV")
+    .multiline()
+    .withBlankLines()
+
+  @Test
+  void setsType()
+  {
+    assertThat builder.build().type, CoreMatchers.is("freddie")
+  }
+
+  @Test
+  void setsFirstLine()
+  {
+    assertThat builder.build().firstLine, CoreMatchers.is("5 September 1946")
+  }
+
+  @Test
+  void setsEndLine()
+  {
+    assertThat builder.build().endLine, CoreMatchers.is("24 November 1991")
+  }
+
+  @Test
+  void setsBeforeEachLine()
+  {
+    assertThat builder.build().beforeEachLine, CoreMatchers.is("Rock")
+  }
+
+  @Test
+  void setsFirstLineDetectionPattern()
+  {
+    assertThat builder.build().isFirstHeaderLine("First day"), CoreMatchers.is(true)
+  }
+
+  @Test
+  void setsLastLineDetectionPattern()
+  {
+    assertThat builder.build().isLastHeaderLine("Last day"), CoreMatchers.is(true)
+  }
+
+  @Test
+  void setsMultiline()
+  {
+    assertThat builder.build().isMultiLine(), CoreMatchers.is(true)
+  }
+
+  @Test
+  void disablesMultiline()
+  {
+    builder.noMultiLine()
+
+    assertThat builder.build().isMultiLine(), CoreMatchers.is(false)
+  }
+
+  @Test
+  void allowsBlankLines()
+  {
+    assertThat builder.build().allowBlankLines(), CoreMatchers.is(true)
+  }
+
+  @Test
+  void noBlankLines()
+  {
+    builder.withNoBlankLines()
+    assertThat builder.build().allowBlankLines(), CoreMatchers.is(false)
+  }
+
+  @Test
+  void setsSkipLines()
+  {
+    assertThat builder.build().isSkipLine("HIV"), CoreMatchers.is(true)
+  }
+
+  @Test
+  void validatesOnBuild()
+  {
+    expectedException.expect(IllegalStateException)
+    expectedException.expectMessage("missing for header definition")
+
+    HeaderDefinitionBuilder.headerDefinition("farrokh_bulsara").build()
+  }
+}


### PR DESCRIPTION
I added a way to define custom header definitions through the gradle dsl

Adding header definitions can be done throught he license extension
This more or less fits with the way it was done in the maven plugin
http://code.mycila.com/license-maven-plugin/#changing-header-style-definitions

```
license {
    headerDefinitions {
        custom_definition {
          firstLine = "//"
          endLine   = "//"
          firstLineDetectionPattern = "//"
          lastLineDetectionPattern  = "//"
          allowBlankLines = false
          skipLinePattern = "//"
          isMultiline = false
        }
    }
}
```