### PR TITLE
Fix for issue 111 - ability to exclude by regex

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -40,10 +40,10 @@ class LicenseResolver {
     private Project project
     private Map<Object, Object> licenses
     private Map<LicenseMetadata, List<Object>> aliases
-    private List<String> dependenciesToIgnore
     private boolean includeProjectDependencies
     private String dependencyConfiguration
     private boolean ignoreFatalParseErrors
+    private List<Pattern> patternsToIgnore
 
     /**
      * Provide set with dependencies metadata.
@@ -97,7 +97,7 @@ class LicenseResolver {
                 }
             }
 
-            provideFileDependencies(p, dependenciesToIgnore).each {
+            provideFileDependencies(p).each {
                 fileDependency ->
                     Closure<DependencyMetadata> licenseMetadata = {
                         if (licenses.containsKey(fileDependency)) {
@@ -135,7 +135,6 @@ class LicenseResolver {
      * Provide full list of resolved artifacts to handle for a given project.
      *
      * @param project                       the project
-     * @param dependenciesToIgnore list of dependencies that will be excluded from the report
      * @return Set with resolved artifacts
      */
     Set<ResolvedArtifact> resolveProjectDependencies(Project project) {
@@ -147,7 +146,7 @@ class LicenseResolver {
             def configuration = project.configurations.getByName(dependencyConfiguration)
             configuration.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact d ->
                 String dependencyDesc = "$d.moduleVersion.id.group:$d.moduleVersion.id.name:$d.moduleVersion.id.version".toString()
-                if(isDependencyIncluded(dependencyDesc, dependenciesToIgnore)) {
+                if(isDependencyIncluded(dependencyDesc)) {
                     Project subproject = subprojects[dependencyDesc]?.first()
                     if (subproject) {
                         if(includeProjectDependencies) {
@@ -165,7 +164,7 @@ class LicenseResolver {
         dependenciesToHandle
     }
 
-    Set<String> provideFileDependencies(Project project, List<String> dependenciesToIgnore) {
+    Set<String> provideFileDependencies(Project project) {
         Set<String> fileDependencies = new HashSet<String>()
 
         if (project.configurations.any { it.name == dependencyConfiguration }) {
@@ -178,7 +177,7 @@ class LicenseResolver {
             d.each {
                 FileCollectionDependency fileDependency ->
                     fileDependency.resolve().each {
-                        if (isDependencyIncluded(it.name, dependenciesToIgnore)) {
+                        if (isDependencyIncluded(it.name)) {
                             fileDependencies.add(it.name)
                         }
                     }
@@ -190,17 +189,15 @@ class LicenseResolver {
         fileDependencies
     }
 
-    boolean isDependencyIncluded(String depName, List<String> patternsToIgnore){
-        for(String pattern: patternsToIgnore){
-            if(depName.equals(pattern)){
-                return false;
-            }
-            if(Pattern.compile(pattern).matcher(depName).matches()){
+    boolean isDependencyIncluded(String depName){
+        for(Pattern pattern: this.patternsToIgnore){
+            if(pattern.matcher(depName).matches()){
                 return false;
             }
         }
         return true;
     }
+
 
     /**
      * Recursive function for retrieving licenses via creating
@@ -280,6 +277,18 @@ class LicenseResolver {
             retrieveLicensesForDependency(project, "$parentGroup:$parentName:$parentVersion", initialDependency)
         } else {
             noLicenseMetaData(dependencyDesc)
+        }
+    }
+
+    void setDependenciesToIgnore(List<String> dependenciesToIgnore){
+        if(dependenciesToIgnore == null){
+            this.patternsToIgnore = Collections.emptyList();
+            return;
+        }
+
+        this.patternsToIgnore = new ArrayList<>(dependenciesToIgnore.size());
+        for(String toIgnore: dependenciesToIgnore){
+            this.patternsToIgnore.add(Pattern.compile(toIgnore))
         }
     }
 }

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -147,7 +147,7 @@ class LicenseResolver {
             def configuration = project.configurations.getByName(dependencyConfiguration)
             configuration.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact d ->
                 String dependencyDesc = "$d.moduleVersion.id.group:$d.moduleVersion.id.name:$d.moduleVersion.id.version".toString()
-                if(!dependenciesToIgnore.contains(dependencyDesc)) {
+                if(isDependencyIncluded(dependencyDesc, dependenciesToIgnore)) {
                     Project subproject = subprojects[dependencyDesc]?.first()
                     if (subproject) {
                         if(includeProjectDependencies) {


### PR DESCRIPTION
Hi,

I've added an enhancement to fix issue request https://github.com/hierynomus/license-gradle-plugin/issues/111

This adds the ability to exclude dependencies from report by Java regex matching as well as exact matching.

I know that you would prefer the to do matching logic based on group and module name so please cancel this if you feel it's not in line with what you would like. 

Thanks,
Shaun