### PR TITLE
Return the initial dependency when no parents have a license

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -276,7 +276,7 @@ class LicenseResolver {
 
             retrieveLicensesForDependency(project, "$parentGroup:$parentName:$parentVersion", initialDependency)
         } else {
-            noLicenseMetaData(dependencyDesc)
+            noLicenseMetaData(initialDependency)
         }
     }
 

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/DownloadLicensesIntegTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/DownloadLicensesIntegTest.groovy
@@ -748,6 +748,42 @@ class DownloadLicensesIntegTest extends Specification {
         !xmlByDependency.dependency.license.find { it['@url'] == "testDependency.jar" }.asBoolean()
     }
 
+	def "Test that if dependency has no license then parent license will be reported"() {
+		setup:
+		project.dependencies {
+			compile 'org.springframework.vault:spring-vault-core:1.1.1.RELEASE'
+		}
+
+		when:
+		downloadLicenses.execute()
+
+		then:
+		File f = getLicenseReportFolder()
+		assertLicenseReportsExist(f)
+
+		def xmlByDependency = xml4LicenseByDependencyReport(f)
+
+		dependencyWithLicensePresent(xmlByDependency, "org.springframework.vault:spring-vault-core:1.1.1.RELEASE", "spring-vault-core-1.1.1.RELEASE.jar", "Apache License, Version 2.0")
+	}
+	
+	def "Test that if dependency and none of its parents have a license it is reported as not found"() {
+		setup:
+        project.dependencies {
+            compile 'org.antlr:antlr-runtime:3.4'
+        }
+
+		when:
+		downloadLicenses.execute()
+
+		then:
+		File f = getLicenseReportFolder()
+		assertLicenseReportsExist(f)
+
+		def xmlByDependency = xml4LicenseByDependencyReport(f)
+
+		dependencyWithLicensePresent(xmlByDependency, "org.antlr:antlr-runtime:3.4", "antlr-runtime-3.4.jar", "No license found")
+	}
+	
     def "Test if a dependency from a local repository without pom should be excluded"() {
       setup:
       File flatRepoDir = new File(projectDir, "libs")


### PR DESCRIPTION
In cases where none of the parents have a dependency, it was
returning the description of the terminal parent. As an example,
for `org.antlr:antlr-runtime:3.4`, this would result in an entry
in `dependency-license.xml` for `org.sonatype.oss:oss-parent:7`
which would obscure the original dependency.