### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ cache:
 
 language: groovy
 
+script:
+  - ./gradlew -Dscan=true build
+
 jdk:
   - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,18 @@ buildscript {
 }
 
 plugins {
+  id 'com.gradle.build-scan' version '1.16'
   id 'groovy'
   id 'idea'
   id "org.ajoberstar.release-opinion" version "1.4.2"
   id 'com.gradle.plugin-publish' version '0.10.0'
   id 'java-gradle-plugin'
   id 'ru.vyarus.animalsniffer' version '1.4.2'
+}
+
+buildScan {
+  termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+  termsOfServiceAgree = 'yes'
 }
 
 apply plugin: 'com.github.hierynomus.license'


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.