### PR TITLE
Fix getting licenses on Android.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,30 +1,29 @@
 // First, apply the publishing plugin
 buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-      jcenter()
+    repositories {
+        maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://dl.google.com/dl/android/maven2/" }
+        jcenter()
     }
-  }
-  dependencies {
-    classpath "com.gradle.publish:plugin-publish-plugin:0.9.1"
-    classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:2.2.+'
-  }
+    dependencies {
+        classpath "com.gradle.publish:plugin-publish-plugin:0.9.1"
+        classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:2.2.+'
+    }
 }
 
 plugins {
-  id 'com.gradle.build-scan' version '2.0.2'
-  id 'groovy'
-  id 'idea'
-  id "org.ajoberstar.release-opinion" version "1.4.2"
-  id 'com.gradle.plugin-publish' version '0.10.0'
-  id 'java-gradle-plugin'
-  id 'ru.vyarus.animalsniffer' version '1.5.0'
+    id 'com.gradle.build-scan' version '2.0.2'
+    id 'groovy'
+    id 'idea'
+    id "org.ajoberstar.release-opinion" version "1.4.2"
+    id 'com.gradle.plugin-publish' version '0.10.0'
+    id 'java-gradle-plugin'
+    id 'ru.vyarus.animalsniffer' version '1.5.0'
 }
 
 buildScan {
-  termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-  termsOfServiceAgree = 'yes'
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 apply plugin: 'com.github.hierynomus.license'
@@ -36,7 +35,12 @@ group = 'com.hierynomus.gradle.plugins'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
-repositories { jcenter() }
+
+repositories {
+    maven { url "https://plugins.gradle.org/m2/" }
+    maven { url "https://dl.google.com/dl/android/maven2/" }
+    jcenter()
+}
 
 idea {
     module {
@@ -46,24 +50,24 @@ idea {
 }
 
 release {
-  grgit = org.ajoberstar.grgit.Grgit.open(project.projectDir)
+    grgit = org.ajoberstar.grgit.Grgit.open(project.projectDir)
 }
 
 configurations.compile.transitive = false
 
 dependencies {
-  signature 'org.codehaus.mojo.signature:java17:1.0@signature'
+    signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 
     compile "org.codehaus.plexus:plexus-utils:2.0.5"
     compile "com.mycila.xmltool:xmltool:3.3"
     // Using compile instead of groovy, so that it goes into the pom
-    compile ('com.mycila:license-maven-plugin:3.0') {
+    compile('com.mycila:license-maven-plugin:3.0') {
         exclude group: 'org.apache.maven', module: 'maven-plugin-api'
         exclude group: 'org.apache.maven', module: 'maven-project'
     }
     compile gradleApi()
 
-    def androidGradlePlugin = ':com.android.tools.build:gradle3.6.3'
+    def androidGradlePlugin = 'com.android.tools.build:gradle:3.6.3'
     compileOnly androidGradlePlugin
     testCompile androidGradlePlugin
 
@@ -98,13 +102,13 @@ license {
 }
 
 test {
-  afterSuite { descriptor, result ->
-    def indicator = "\u001B[32m✓\u001b[0m"
-    if (result.failedTestCount > 0) {
-      indicator = "\u001B[31m✘\u001b[0m"
+    afterSuite { descriptor, result ->
+        def indicator = "\u001B[32m✓\u001b[0m"
+        if (result.failedTestCount > 0) {
+            indicator = "\u001B[31m✘\u001b[0m"
+        }
+        logger.lifecycle("$indicator Test ${descriptor.name}; Executed: ${result.testCount}/\u001B[32m${result.successfulTestCount}\u001B[0m/\u001B[31m${result.failedTestCount}\u001B[0m")
     }
-    logger.lifecycle("$indicator Test ${descriptor.name}; Executed: ${result.testCount}/\u001B[32m${result.successfulTestCount}\u001B[0m/\u001B[31m${result.failedTestCount}\u001B[0m")
-  }
 }
 
 def pomConfig = {
@@ -181,7 +185,7 @@ pluginBundle {
         licenseReportPlugin {
             displayName = "License Report plugin for Gradle"
             description = "Reports over licenses"
-            tags = [ "gradle", "plugin", "license", "report" ]
+            tags = ["gradle", "plugin", "license", "report"]
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     }
     compile gradleApi()
 
-    def androidGradlePlugin = 'com.android.tools.build:gradle:2.0.+'
+    def androidGradlePlugin = ':com.android.tools.build:gradle3.6.3'
     compileOnly androidGradlePlugin
     testCompile androidGradlePlugin
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
   id "org.ajoberstar.release-opinion" version "1.4.2"
   id 'com.gradle.plugin-publish' version '0.10.0'
   id 'java-gradle-plugin'
-  id 'ru.vyarus.animalsniffer' version '1.4.2'
+  id 'ru.vyarus.animalsniffer' version '1.5.0'
 }
 
 buildScan {

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id "org.ajoberstar.release-opinion" version "1.4.2"
     id 'com.gradle.plugin-publish' version '0.10.0'
     id 'java-gradle-plugin'
-    id 'ru.vyarus.animalsniffer' version '1.5.0'
+    id 'ru.vyarus.animalsniffer' version '1.5.1'
 }
 
 buildScan {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.publish:plugin-publish-plugin:0.9.1"
-        classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:2.2.+'
+        classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:2.2.2'
     }
 }
 
@@ -98,6 +98,11 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 license {
+    ignoreFailures true
+}
+
+animalsniffer {
+    excludeJars 'gradle-api-*'
     ignoreFailures true
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // First, apply the publishing plugin
 buildscript {
     repositories {
-        maven { url "https://plugins.gradle.org/m2/" }
-        maven { url "https://dl.google.com/dl/android/maven2/" }
+        gradlePluginPortal()
+        google()
         jcenter()
     }
     dependencies {
@@ -37,8 +37,8 @@ targetCompatibility = 1.7
 
 
 repositories {
-    maven { url "https://plugins.gradle.org/m2/" }
-    maven { url "https://dl.google.com/dl/android/maven2/" }
+    gradlePluginPortal()
+    google()
     jcenter()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.gradle.build-scan' version '1.16'
+  id 'com.gradle.build-scan' version '2.0.2'
   id 'groovy'
   id 'idea'
   id "org.ajoberstar.release-opinion" version "1.4.2"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'groovy'
 
 repositories {
+    maven { url "https://plugins.gradle.org/m2/" }
+    maven { url "https://dl.google.com/dl/android/maven2/" }
     jcenter()
 }
 
@@ -9,13 +11,13 @@ configurations.compile.transitive = false
 dependencies {
     compile "org.codehaus.plexus:plexus-utils:2.0.5"
     compile "com.mycila.xmltool:xmltool:3.3"
-    compile ('com.mycila:license-maven-plugin:3.0') {
+    compile('com.mycila:license-maven-plugin:3.0') {
         exclude group: 'org.apache.maven', module: 'maven-plugin-api'
         exclude group: 'org.apache.maven', module: 'maven-project'
     }
     compile gradleApi()
 
-    compileOnly 'com.android.tools.build:gradle:2.0.+'
+    compileOnly 'com.android.tools.build:gradle:3.6.3'
 }
 
 sourceSets {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 08 16:48:23 EST 2014
+#Mon Apr 20 15:51:30 BST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -172,7 +172,7 @@ class LicenseResolver {
 
     Set<ResolvedArtifact> getResolvedArtifacts(Configuration configuration) {
         if (!isResolvable(configuration) || isTest(configuration) || !isPackagedDependency(configuration)) {
-            logger.warn("Failed to resolve OSS licenses for $configuration.name.", exception)
+            logger.warn("Failed to resolve OSS licenses for $configuration.name.")
         } else {
             try {
                 return getResolvedArtifactsFromResolvedDependencies(
@@ -243,7 +243,7 @@ class LicenseResolver {
      * @param conf Configuration
      * @return whether conf is resolvable
      *
-     * @see <ahref="https://docs.gradle.org/3.4/release-notes.html#configurations-can-be-unresolvable"                   >                   Gradle 3.4 release notes</a>
+     * @see <ahref="https://docs.gradle.org/3.4/release-notes.html#configurations-can-be-unresolvable">Gradle 3.4 release notes</a>
      */
     boolean isResolvable(Configuration conf) {
         return conf.metaClass.respondsTo(conf, "isCanBeResolved") ? conf.isCanBeResolved() : true

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -150,7 +150,7 @@ class LicenseResolver {
         Set<ResolvedArtifact> dependenciesToHandle = new HashSet<ResolvedArtifact>()
 
         project.configurations.each { Configuration configuration ->
-            if (!canBeResolved(configuration) || isTest(configuration) || !isPackagedDependency(configuration)) {
+            if (!isResolvable(configuration) || isTest(configuration) || !isPackagedDependency(configuration)) {
                 return null
             } else {
                 try {

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -245,7 +245,7 @@ class LicenseResolver {
      * @param conf Configuration
      * @return whether conf is resolvable
      *
-     * @see <ahref="https://docs.gradle.org/3.4/release-notes.html#configurations-can-be-unresolvable"    >    Gradle 3.4 release notes</a>
+     * @see <ahref="https://docs.gradle.org/3.4/release-notes.html#configurations-can-be-unresolvable" > Gradle 3.4 release notes</a>
      */
     boolean isResolvable(Configuration conf) {
         return conf.metaClass.respondsTo(conf, "isCanBeResolved") ? conf.isCanBeResolved() : true
@@ -260,8 +260,7 @@ class LicenseResolver {
      */
     protected boolean isTest(Configuration configuration) {
         boolean isTestConfiguration = (configuration.name.startsWith(TEST_PREFIX) || configuration.name.startsWith(ANDROID_TEST_PREFIX))
-        configuration.hierarchy.each { isTestConfiguration |= TEST_COMPILE.contains(it.name) }
-        return isTestConfiguration
+        return isTestConfiguration || configuration.hierarchy.any { TEST_COMPILE.contains(it.name) }
     }
 
     /**
@@ -285,12 +284,7 @@ class LicenseResolver {
 
 
     boolean isDependencyIncluded(String depName) {
-        for (Pattern pattern : this.patternsToIgnore) {
-            if (pattern.matcher(depName).matches()) {
-                return false;
-            }
-        }
-        return true;
+        return !patternsToIgnore.any { it.matcher(depName).matches() }
     }
 
 

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -159,7 +159,7 @@ class LicenseResolver {
                                     .getLenientConfiguration()
                                     .getFirstLevelModuleDependencies())
 
-                    logger.info(configuration.name + " -> " + deps.count())
+                    logger.info(configuration.name + " -> " + deps.size())
 
                     dependenciesToHandle.addAll(deps)
 

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -182,6 +182,8 @@ class LicenseResolver {
 
             } catch (ResolveException exception) {
                 logger.warn("Failed to resolve OSS licenses for $configuration.name.", exception)
+            } catch (Exception exception) {
+                logger.warn("Failed to resolve OSS licenses for $configuration.name.", exception)
             }
         }
 
@@ -243,7 +245,7 @@ class LicenseResolver {
      * @param conf Configuration
      * @return whether conf is resolvable
      *
-     * @see <ahref="https://docs.gradle.org/3.4/release-notes.html#configurations-can-be-unresolvable">Gradle 3.4 release notes</a>
+     * @see <ahref="https://docs.gradle.org/3.4/release-notes.html#configurations-can-be-unresolvable"    >    Gradle 3.4 release notes</a>
      */
     boolean isResolvable(Configuration conf) {
         return conf.metaClass.respondsTo(conf, "isCanBeResolved") ? conf.isCanBeResolved() : true

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -21,12 +21,14 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 
 import java.util.regex.Pattern
 
 import static DependencyMetadata.noLicenseMetaData
+
 /**
  * License resolver for dependencies.
  */
@@ -45,7 +47,7 @@ class LicenseResolver {
     private boolean ignoreFatalParseErrors
     private List<Pattern> patternsToIgnore
 
-    private static final Set<String> PACKAGED_DEPENDENCIES_PREFIXES = ["compile","implementation","api"]
+    private static final Set<String> PACKAGED_DEPENDENCIES_PREFIXES = ["compile", "implementation", "api"]
 
     /**
      * Provide set with dependencies metadata.
@@ -57,7 +59,7 @@ class LicenseResolver {
      */
     public Set<DependencyMetadata> provideLicenseMap4Dependencies() {
         Set<DependencyMetadata> licenseSet = new HashSet<DependencyMetadata>()
-        def subprojects = project.rootProject.subprojects.groupBy { Project p -> "$p.group:$p.name:$p.version".toString()}
+        def subprojects = project.rootProject.subprojects.groupBy { Project p -> "$p.group:$p.name:$p.version".toString() }
 
         Set<Project> projects = new HashSet<Project>()
         projects.add(project)
@@ -66,68 +68,68 @@ class LicenseResolver {
         projects.each {
             p ->
 
-            // Resolve each dependency
-            resolveProjectDependencies(p).each {
-                rd ->
-                String dependencyDesc = "$rd.moduleVersion.id.group:$rd.moduleVersion.id.name:$rd.moduleVersion.id.version".toString()
-                Map.Entry licenseEntry = licenses.find {
-                    dep ->
-                    if(dep.key instanceof String) {
-                        dep.key == dependencyDesc
-                    } else if (dep.key instanceof DependencyGroup) {
-                        rd.moduleVersion.id.group == dep.key.group
-                    }
-                }
-                if (licenseEntry != null) {
-                    def license = licenseEntry.value
-                    def licenseMetadata = license instanceof String ? DownloadLicensesExtension.license(license) : license
-                    licenseSet << new DependencyMetadata(
-                            dependency: dependencyDesc, dependencyFileName: rd.file.name, licenseMetadataList: [ licenseMetadata ]
-                    )
-                } else {
-                    Closure<DependencyMetadata> dependencyMetadata = {
-                        if(!subprojects[dependencyDesc]) {
-                            def depMetadata = retrieveLicensesForDependency(p, dependencyDesc)
-                            depMetadata.dependencyFileName = rd.file.name
-                            depMetadata
-                        } else {
-                            noLicenseMetaData(dependencyDesc, rd.file.name)
+                // Resolve each dependency
+                resolveProjectDependencies(p).each {
+                    rd ->
+                        String dependencyDesc = "$rd.moduleVersion.id.group:$rd.moduleVersion.id.name:$rd.moduleVersion.id.version".toString()
+                        Map.Entry licenseEntry = licenses.find {
+                            dep ->
+                                if (dep.key instanceof String) {
+                                    dep.key == dependencyDesc
+                                } else if (dep.key instanceof DependencyGroup) {
+                                    rd.moduleVersion.id.group == dep.key.group
+                                }
                         }
-                    }
-
-                    licenseSet << dependencyMetadata()
-                }
-            }
-
-            provideFileDependencies(p).each {
-                fileDependency ->
-                    Closure<DependencyMetadata> licenseMetadata = {
-                        if (licenses.containsKey(fileDependency)) {
-                            def license = licenses[fileDependency]
-                            LicenseMetadata licenseMetadata = license instanceof String ? DownloadLicensesExtension.license(license) : license
-                            def alias = aliases.find {
-                                aliasEntry ->
-                                    aliasEntry.value.any {
-                                        aliasElem ->
-                                            if (aliasElem instanceof String) {
-                                                return aliasElem == licenseMetadata.licenseName
-                                            } else if(aliasElem instanceof LicenseMetadata) {
-                                                return aliasElem == licenseMetadata
-                                            }
-
-                                    }
-                            }
-                            if (alias) {
-                                licenseMetadata = alias.key
-                            }
-                            new DependencyMetadata(dependency: fileDependency, dependencyFileName: fileDependency, licenseMetadataList: [licenseMetadata])
+                        if (licenseEntry != null) {
+                            def license = licenseEntry.value
+                            def licenseMetadata = license instanceof String ? DownloadLicensesExtension.license(license) : license
+                            licenseSet << new DependencyMetadata(
+                                    dependency: dependencyDesc, dependencyFileName: rd.file.name, licenseMetadataList: [licenseMetadata]
+                            )
                         } else {
-                            noLicenseMetaData(fileDependency, fileDependency)
-                        }
-                    }
+                            Closure<DependencyMetadata> dependencyMetadata = {
+                                if (!subprojects[dependencyDesc]) {
+                                    def depMetadata = retrieveLicensesForDependency(p, dependencyDesc)
+                                    depMetadata.dependencyFileName = rd.file.name
+                                    depMetadata
+                                } else {
+                                    noLicenseMetaData(dependencyDesc, rd.file.name)
+                                }
+                            }
 
-                    licenseSet << licenseMetadata()
-            }
+                            licenseSet << dependencyMetadata()
+                        }
+                }
+
+                provideFileDependencies(p).each {
+                    fileDependency ->
+                        Closure<DependencyMetadata> licenseMetadata = {
+                            if (licenses.containsKey(fileDependency)) {
+                                def license = licenses[fileDependency]
+                                LicenseMetadata licenseMetadata = license instanceof String ? DownloadLicensesExtension.license(license) : license
+                                def alias = aliases.find {
+                                    aliasEntry ->
+                                        aliasEntry.value.any {
+                                            aliasElem ->
+                                                if (aliasElem instanceof String) {
+                                                    return aliasElem == licenseMetadata.licenseName
+                                                } else if (aliasElem instanceof LicenseMetadata) {
+                                                    return aliasElem == licenseMetadata
+                                                }
+
+                                        }
+                                }
+                                if (alias) {
+                                    licenseMetadata = alias.key
+                                }
+                                new DependencyMetadata(dependency: fileDependency, dependencyFileName: fileDependency, licenseMetadataList: [licenseMetadata])
+                            } else {
+                                noLicenseMetaData(fileDependency, fileDependency)
+                            }
+                        }
+
+                        licenseSet << licenseMetadata()
+                }
         }
 
         licenseSet
@@ -136,35 +138,66 @@ class LicenseResolver {
     /**
      * Provide full list of resolved artifacts to handle for a given project.
      *
-     * @param project                       the project
+     * @param project the project
      * @return Set with resolved artifacts
      */
     Set<ResolvedArtifact> resolveProjectDependencies(Project project) {
 
         Set<ResolvedArtifact> dependenciesToHandle = new HashSet<ResolvedArtifact>()
-        def subprojects = project.rootProject.subprojects.groupBy { Project p -> "$p.group:$p.name:$p.version".toString()}
+        def subprojects = project.rootProject.subprojects.groupBy { Project p -> "$p.group:$p.name:$p.version".toString() }
 
-        if (project.configurations.any { it.name == dependencyConfiguration && (isResolvable(it) || isPackagedDependency(it)) }) {
+        if (project.configurations.any {
+            it.name == dependencyConfiguration && (isResolvable(it) || isPackagedDependency(it))
+        }) {
             def configuration = project.configurations.getByName(dependencyConfiguration)
-            configuration.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact d ->
-                String dependencyDesc = "$d.moduleVersion.id.group:$d.moduleVersion.id.name:$d.moduleVersion.id.version".toString()
-                if(isDependencyIncluded(dependencyDesc)) {
-                    Project subproject = subprojects[dependencyDesc]?.first()
-                    if (subproject) {
-                        if(includeProjectDependencies) {
-                            dependenciesToHandle.add(d)
-                        }
-                        dependenciesToHandle.addAll(resolveProjectDependencies(subproject))
-                    } else if (!subproject) {
-                        dependenciesToHandle.add(d)
-                    }
-                }
-            }
+
+            dependenciesToHandle.addAll(getResolvedArtifactsFromResolvedDependencies(configuration.getResolvedConfiguration()
+                    .getLenientConfiguration()
+                    .getFirstLevelModuleDependencies()))
+
+//            configuration.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact d ->
+//                String dependencyDesc = "$d.moduleVersion.id.group:$d.moduleVersion.id.name:$d.moduleVersion.id.version".toString()
+//                if (isDependencyIncluded(dependencyDesc)) {
+//                    Project subproject = subprojects[dependencyDesc]?.first()
+//                    if (subproject) {
+//                        if (includeProjectDependencies) {
+//                            dependenciesToHandle.add(d)
+//                        }
+//                        dependenciesToHandle.addAll(resolveProjectDependencies(subproject))
+//                    } else if (!subproject) {
+//                        dependenciesToHandle.add(d)
+//                    }
+//                }
+//            }
         }
 
         logger.debug("Project $project.name found ${dependenciesToHandle.size()} dependencies to handle.")
         dependenciesToHandle
     }
+
+    protected Set<ResolvedArtifact> getResolvedArtifactsFromResolvedDependencies(Set<ResolvedDependency> resolvedDependencies) {
+        HashSet<ResolvedArtifact> resolvedArtifacts = new HashSet<>()
+
+        for (resolvedDependency in resolvedDependencies) {
+            try {
+                if (resolvedDependency.getModuleVersion() == LOCAL_LIBRARY_VERSION) {
+                    /**
+                     * Attempting to getAllModuleArtifacts on a local library project will result
+                     * in AmbiguousVariantSelectionException as there are not enough criteria
+                     * to match a specific variant of the library project. Instead we skip the
+                     * the library project itself and enumerate its dependencies.
+                     */
+                    resolvedArtifacts.addAll(getResolvedArtifactsFromResolvedDependencies(resolvedDependency.getChildren()))
+                } else {
+                    resolvedArtifacts.addAll(resolvedDependency.getAllModuleArtifacts())
+                }
+            } catch (Exception exception) {
+                logger.warn("Failed to process $resolvedDependency.name", exception)
+            }
+        }
+        return resolvedArtifacts
+    }
+
 
     Set<String> provideFileDependencies(Project project) {
         Set<String> fileDependencies = new HashSet<String>()
@@ -197,13 +230,13 @@ class LicenseResolver {
      * @param conf Configuration
      * @return whether conf is resolvable
      *
-     * @see <a href="https://docs.gradle.org/3.4/release-notes.html#configurations-can-be-unresolvable">Gradle 3.4 release notes</a>
+     * @see <ahref="https://docs.gradle.org/3.4/release-notes.html#configurations-can-be-unresolvable"    >    Gradle 3.4 release notes</a>
      */
     boolean isResolvable(Configuration conf) {
         return conf.metaClass.respondsTo(conf, "isCanBeResolved") ? conf.isCanBeResolved() : true
     }
- 
-    
+
+
     /**
      * Checks if the configuration is for a packaged dependency (rather than e.g. a build or test time dependency)
      * @param configuration
@@ -222,11 +255,11 @@ class LicenseResolver {
 
         return isPackagedDependency
     }
-    
 
-    boolean isDependencyIncluded(String depName){
-        for(Pattern pattern: this.patternsToIgnore){
-            if(pattern.matcher(depName).matches()){
+
+    boolean isDependencyIncluded(String depName) {
+        for (Pattern pattern : this.patternsToIgnore) {
+            if (pattern.matcher(depName).matches()) {
                 return false;
             }
         }
@@ -244,7 +277,7 @@ class LicenseResolver {
      * Implementation note: We rely that while resolving configuration with one dependency we get one pom.
      * Otherwise we have IllegalStateException
      *
-     * @param project                       the project
+     * @param project the project
      * @param dependencyDesc dependency description
      * @param aliases alias mapping for similar license names
      * @param initialDependency base dependency (not parent)
@@ -289,8 +322,8 @@ class LicenseResolver {
                     aliasEntry.value.any {
                         aliasElem ->
                             if (aliasElem instanceof String) {
-                               return aliasElem == license.licenseName
-                            } else if(aliasElem instanceof LicenseMetadata) {
+                                return aliasElem == license.licenseName
+                            } else if (aliasElem instanceof LicenseMetadata) {
                                 return aliasElem == license
                             }
 
@@ -315,14 +348,14 @@ class LicenseResolver {
         }
     }
 
-    void setDependenciesToIgnore(List<String> dependenciesToIgnore){
-        if(dependenciesToIgnore == null){
+    void setDependenciesToIgnore(List<String> dependenciesToIgnore) {
+        if (dependenciesToIgnore == null) {
             this.patternsToIgnore = Collections.emptyList();
             return;
         }
 
         this.patternsToIgnore = new ArrayList<>(dependenciesToIgnore.size());
-        for(String toIgnore: dependenciesToIgnore){
+        for (String toIgnore : dependenciesToIgnore) {
             this.patternsToIgnore.add(Pattern.compile(toIgnore))
         }
     }

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -159,7 +159,7 @@ class LicenseResolver {
                                     .getLenientConfiguration()
                                     .getFirstLevelModuleDependencies())
 
-                    logger.info(configuration.name + " -> " + deps.size())
+                    println(configuration.name + " -> " + deps.size())
 
                     dependenciesToHandle.addAll(deps)
 

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -153,7 +153,7 @@ class LicenseResolver {
             def configuration = project.configurations.getByName(dependencyConfiguration)
 
             if (!isResolvable(configuration) || isTest(configuration) || !isPackagedDependency(configuration)) {
-                println(configuration.name + " ->  no no no")
+                println(project.name + " -> " + configuration.name + " -> no no no")
             } else {
                 try {
                     Set<ResolvedArtifact> deps = getResolvedArtifactsFromResolvedDependencies(
@@ -163,7 +163,7 @@ class LicenseResolver {
 
                     dependenciesToHandle.addAll(deps)
 
-                    println(configuration.name + " -> " + deps.size())
+                    println(project.name + " -> " + configuration.name + " -> " + deps.size())
 
                 } catch (ResolveException exception) {
                     logger.warn("Failed to resolve OSS licenses for $configuration.name.", exception)

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -159,6 +159,8 @@ class LicenseResolver {
                                     .getLenientConfiguration()
                                     .getFirstLevelModuleDependencies())
 
+                    logger.info(configuration.name + " -> " + deps.count())
+
                     dependenciesToHandle.addAll(deps)
 
                 } catch (ResolveException exception) {

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseResolver.groovy
@@ -148,8 +148,8 @@ class LicenseResolver {
      */
     Set<ResolvedArtifact> resolveProjectDependencies(Project project) {
         Set<ResolvedArtifact> dependenciesToHandle = new HashSet<ResolvedArtifact>()
-        
-        project.configurations.each {
+
+        project.configurations.each { Configuration configuration ->
             if (!canBeResolved(configuration) || isTest(configuration) || !isPackagedDependency(configuration)) {
                 return null
             } else {


### PR DESCRIPTION
Licenses were always coming up blank on Android used some logic from [oss-licenses-plugin](https://github.com/google/play-services-plugins/blob/master/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy).

Tested with following config in root `build.gradle`.
```
buildscript {
    ...
    repositories {
        ...
        maven { url "https://jitpack.io" }
    }
    dependencies {
        classpath 'com.android.tools.build:gradle:3.6.1'
        ...
        classpath "com.github.nic-bell:license-gradle-plugin:cac7e1c79a"
    }
}

allprojects {
    ...
    apply plugin: "com.github.hierynomus.license-report"
}

downloadLicenses {
    includeProjectDependencies = true
    dependencyConfiguration = 'releaseRuntimeClasspath'
}
```

Should fix #174 #182