### PR TITLE
Expose the keywords option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -115,6 +115,7 @@ most of which can also be set on the extension to configure them for all tasks.
 |dryRun |Show what would happen if the task was run, defaults to false but also inherits from `--dryRun`
 |skipExistingHeaders |Skip over files that have some header already, which might not be the one specified in the header parameter, defaults to false
 |useDefaultMappings |Use a long list of standard mapping, defaults to true. See http://code.mycila.com/license-maven-plugin/#supported-comment-types[] for the complete list
+|keywords |Specify the list of keywords to use to detect a header. A header must include all keywords to be valid. By default, the word 'copyright' is used. Detection is case insensitive.
 |strictCheck |Be extra strict in the formatting of existing headers, defaults to false
 |mapping(String ext, String style) |Adds a mapping between a file extension and a style type
 |mapping(Map<String,String> mappings) |Adds mappings between file extensions and style types
@@ -137,6 +138,7 @@ most of which can also be set on the extension to configure them for all tasks.
 |dryRun |Show what would happen if the task was run, defaults to false but also inherits from `--dryRun`
 |skipExistingHeaders |Skip over files that have some header already, which might not be the one specified in the header parameter, defaults to false
 |useDefaultMappings |Use a long list of standard mapping, defaults to true. See http://code.mycila.com/license-maven-plugin/#supported-comment-types[] for the complete list
+|keywords |Specify the list of keywords to use to detect a header. A header must include all keywords to be valid. By default, the word 'copyright' is used. Detection is case insensitive.
 |strictCheck |Be extra strict in the formatting of existing headers, defaults to false
 |mapping(String ext, String style) |Adds a mapping between a file extension and a style type
 |mapping(Map<String,String> mappings) |Adds mappings between file extensions and style types
@@ -168,6 +170,7 @@ Here is a general overview of the options:
 |dryRun |Show what would happen if the task was run, defaults to false but also inherits from `--dryRun`
 |skipExistingHeaders |Skip over files that have some header already, which might not be the one specified in the header parameter, defaults to false
 |useDefaultMappings |Use a long list of standard mapping, defaults to true. See http://code.mycila.com/license-maven-plugin/#supported-comment-types[] for the complete list
+|keywords |Specify the list of keywords to use to detect a header. A header must include all keywords to be valid. By default, the word 'copyright' is used. Detection is case insensitive.
 |strictCheck |Be extra strict in the formatting of existing headers, defaults to false
 |mapping(String ext, String style) |Adds a mapping between a file extension and a style type
 |mapping(Map<String,String> mappings) |Adds mappings between file extensions and style types

--- a/src/main/groovy/com/hierynomus/gradle/license/LicenseBasePlugin.groovy
+++ b/src/main/groovy/com/hierynomus/gradle/license/LicenseBasePlugin.groovy
@@ -76,6 +76,7 @@ class LicenseBasePlugin implements Plugin<Project> {
             dryRun = false
             skipExistingHeaders = false
             useDefaultMappings = true
+            keywords = ['copyright']
             strictCheck = false
             encoding = System.properties['file.encoding']
             sourceSets = project.container(SourceSet)
@@ -113,6 +114,7 @@ class LicenseBasePlugin implements Plugin<Project> {
             dryRun = { extension.dryRun }
             skipExistingHeaders = { extension.skipExistingHeaders }
             useDefaultMappings = { extension.useDefaultMappings }
+            keywords = { extension.keywords }
             strictCheck = { extension.strictCheck }
             inheritedProperties = { extension.ext.properties }
             inheritedMappings = { extension.internalMappings }

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
@@ -64,6 +64,12 @@ class License extends SourceTask implements VerificationTask {
      */
     @Input boolean useDefaultMappings
 
+    /**
+     * Specify the list of keywords to use to detect a header. A header must
+     * include all keywords to be valid. Detection is case insensitive.
+     */
+    @Input Collection<String> keywords;
+
     @Input boolean strictCheck
 
     /**
@@ -135,7 +141,7 @@ class License extends SourceTask implements VerificationTask {
 
         URI uri = resolveURI()
 
-        new AbstractLicenseMojo(validHeaders, getProject().rootDir, initial, isDryRun(), isSkipExistingHeaders(), isUseDefaultMappings(), isStrictCheck(), uri, source, combinedMappings, getEncoding(), buildHeaderDefinitions())
+        new AbstractLicenseMojo(validHeaders, getProject().rootDir, initial, isDryRun(), isSkipExistingHeaders(), isUseDefaultMappings(), isStrictCheck(), uri, source, combinedMappings, getEncoding(), buildHeaderDefinitions(), getKeywords())
             .execute(callback)
 
         altered = callback.getAffected()

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseExtension.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/LicenseExtension.groovy
@@ -72,6 +72,12 @@ class LicenseExtension {
      */
     boolean useDefaultMappings
 
+    /**
+     * Specify the list of keywords to use to detect a header. A header must
+     * include all keywords to be valid. Detection is case insensitive.
+     */
+    Collection<String> keywords
+
     boolean strictCheck
 
     /**

--- a/src/main/groovy/nl/javadude/gradle/plugins/license/maven/AbstractLicenseMojo.java
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/maven/AbstractLicenseMojo.java
@@ -59,7 +59,7 @@ public class AbstractLicenseMojo {
     File rootDir;
     Map<String, String> initial;
 
-    protected String[] keywords = new String[] { "copyright" };
+    protected String[] keywords;
     protected List<HeaderDefinition> headerDefinitions;
     protected HeaderSection[] headerSections = new HeaderSection[0];
     protected String encoding;
@@ -75,7 +75,8 @@ public class AbstractLicenseMojo {
 
     public AbstractLicenseMojo(Collection<File> validHeaders, File rootDir, Map<String, String> initial,
                     boolean dryRun, boolean skipExistingHeaders, boolean useDefaultMappings, boolean strictCheck,
-                    URI header, FileCollection source, Map<String, String> mapping, String encoding, List<HeaderDefinition> headerDefinitions) {
+                    URI header, FileCollection source, Map<String, String> mapping, String encoding, List<HeaderDefinition> headerDefinitions,
+                    Collection<String> keywords) {
         this.validHeaders = validHeaders;
         this.rootDir = rootDir;
         this.initial = initial;
@@ -88,6 +89,7 @@ public class AbstractLicenseMojo {
         this.mapping = mapping;
         this.encoding = encoding;
         this.headerDefinitions = headerDefinitions;
+        this.keywords = keywords.toArray(new String[0]);
     }
 
     protected void execute(final Callback callback) throws MalformedURLException, IOException {

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
@@ -76,6 +76,11 @@ class LicensePluginTest {
     }
 
     @Test
+    public void extensionKeywordsDefaults() {
+        assertThat project.license.keywords, is(['copyright'])
+    }
+
+    @Test
     public void extensionShouldNotHaveSourceSets() {
         assertThat project.license.sourceSets, is(notNullValue())
         assertThat project.license.sourceSets.size(), equalTo(0)


### PR DESCRIPTION
license-maven-plugin exposes a `keywords` [parameter](https://mycila.carbou.me/license-maven-plugin/reports/3.0/check-mojo.html#keywords) that is used to determine whether a particular comment is a copyright header or not, based on the presence of the specified keywords, defaulting to `["copyright"]`. https://github.com/mathieucarbou/license-maven-plugin/blob/4a664c9fa7f0e5c8dafacc19c4bc771a2ed5e32d/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseSet.java#L122

This PR exposes the same option in gradle, rather than hardcoding it.