### PR TITLE
Make use of Gradle Task Configuration Avoidance for registering tasks

### DIFF
--- a/src/main/groovy/com/hierynomus/gradle/license/LicenseBasePlugin.groovy
+++ b/src/main/groovy/com/hierynomus/gradle/license/LicenseBasePlugin.groovy
@@ -97,7 +97,7 @@ class LicenseBasePlugin implements Plugin<Project> {
      * @param task
      */
     protected void configureTaskRule() {
-        project.tasks.withType(License) { License task ->
+        project.tasks.withType(License).configureEach { License task ->
             logger.info("Applying license defaults to task: ${task.path}");
             configureTaskDefaults(task)
         }

--- a/src/main/groovy/com/hierynomus/gradle/license/LicenseBasePlugin.groovy
+++ b/src/main/groovy/com/hierynomus/gradle/license/LicenseBasePlugin.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.TaskProvider
 
 class LicenseBasePlugin implements Plugin<Project> {
 
@@ -140,12 +141,12 @@ class LicenseBasePlugin implements Plugin<Project> {
             def sourceSetTaskName = "${LICENSE_TASK_BASE_NAME}${taskInfix}${sourceSet.name.capitalize()}"
             logger.info("Adding ${sourceSetTaskName} task for sourceSet ${sourceSet.name}");
 
-            License checkTask = project.tasks.create(sourceSetTaskName, LicenseCheck)
+            TaskProvider<LicenseCheck> checkTask = project.tasks.register(sourceSetTaskName, LicenseCheck)
             configureForSourceSet(sourceSet, checkTask, sourceSetSources)
 
             // Add independent license task, which will perform format
             def sourceSetFormatTaskName = "${FORMAT_TASK_BASE_NAME}${taskInfix}${sourceSet.name.capitalize()}"
-            License formatTask = project.tasks.create(sourceSetFormatTaskName, LicenseFormat)
+            TaskProvider<LicenseFormat> formatTask = project.tasks.register(sourceSetFormatTaskName, LicenseFormat)
             configureForSourceSet(sourceSet, formatTask, sourceSetSources)
 
             // Add independent clean task to remove headers
@@ -153,14 +154,14 @@ class LicenseBasePlugin implements Plugin<Project> {
         }
     }
 
-    protected void configureForSourceSet(sourceSet, License task, Closure<Iterable<File>> sourceSetSources) {
-        task.with {
+    protected static void configureForSourceSet(sourceSet, TaskProvider task, Closure<Iterable<File>> sourceSetSources) {
+        task.configure {
             // Explicitly set description
-            description = "Scanning license on ${sourceSet.name} files"
-        }
+            it.description = "Scanning license on ${sourceSet.name} files"
 
-        // Default to all source files from SourceSet
-        task.source = sourceSetSources(sourceSet)
+            // Default to all source files from SourceSet
+            it.source = sourceSetSources(sourceSet)
+        }
     }
 }
 

--- a/src/main/groovy/com/hierynomus/gradle/license/LicenseReportingPlugin.groovy
+++ b/src/main/groovy/com/hierynomus/gradle/license/LicenseReportingPlugin.groovy
@@ -21,8 +21,8 @@ import nl.javadude.gradle.plugins.license.DownloadLicensesReportExtension
 import nl.javadude.gradle.plugins.license.LicensesReport
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.plugins.ReportingBasePlugin
+import org.gradle.api.tasks.TaskProvider
 
 class LicenseReportingPlugin implements Plugin<Project> {
     static final String DOWNLOAD_LICENSES_TASK_NAME = 'downloadLicenses'
@@ -31,7 +31,7 @@ class LicenseReportingPlugin implements Plugin<Project> {
 
     protected DownloadLicensesExtension downloadLicensesExtension
 
-    protected Task downloadLicenseTask
+    protected TaskProvider<DownloadLicenses> downloadLicenseTask
     private Project project
 
     @Override
@@ -39,14 +39,15 @@ class LicenseReportingPlugin implements Plugin<Project> {
         this.project = project
         project.plugins.apply(ReportingBasePlugin)
         // Create a single task to run all license checks and reformattings
-        downloadLicenseTask = project.tasks.create(DOWNLOAD_LICENSES_TASK_NAME, DownloadLicenses)
+        downloadLicenseTask = project.tasks.register(DOWNLOAD_LICENSES_TASK_NAME, DownloadLicenses) {
+            it.group = "License"
+            it.description = "Generates reports on your runtime dependencies."
+        }
 
-        downloadLicenseTask.group = "License"
-        downloadLicenseTask.description = "Generates reports on your runtime dependencies."
         downloadLicensesExtension = createDownloadLicensesExtension()
 
 
-        project.tasks.withType(DownloadLicenses) { DownloadLicenses task ->
+        project.tasks.withType(DownloadLicenses).configureEach { DownloadLicenses task ->
             project.logger.info("Applying defaults to download task: ${task.path}");
             configureTaskDefaults(task)
         }

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/AndroidLicensePluginTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/AndroidLicensePluginTest.groovy
@@ -166,7 +166,7 @@ class AndroidLicensePluginTest {
         def task = project.tasks.create('licenseManual', LicenseCheck)
 
         Set<Task> dependsOn = project.tasks['check'].getDependsOn()
-        assertThat dependsOn, hasItem(project.tasks['license'])
+        assertThat dependsOn, hasItem(project.tasks.named('license'))
 
         // Manual tests don't get registered with check
         assertThat dependsOn, not(hasItem(task))
@@ -179,7 +179,7 @@ class AndroidLicensePluginTest {
 
         def manualFormat = project.tasks.create('licenseManualFormat', LicenseFormat)
 
-        Set<Task> dependsOn = project.tasks['license'].getDependsOn()
+        Set<Task> dependsOn = project.tasks['license'].getDependsOn().flatten()
         assertThat dependsOn, hasItem(project.tasks['licenseAndroidMain'])
         assertThat dependsOn, hasItem(project.tasks['licenseAndroidAndroidTest'])
 
@@ -187,7 +187,7 @@ class AndroidLicensePluginTest {
         assertThat dependsOn, hasItem(manual)
         assertThat dependsOn, not(hasItem(manualFormat))
 
-        Set<Task> dependsOnFormat = project.tasks['licenseFormat'].getDependsOn()
+        Set<Task> dependsOnFormat = project.tasks['licenseFormat'].getDependsOn().flatten()
         assertThat dependsOnFormat, hasItem(project.tasks['licenseFormatAndroidMain'])
         assertThat dependsOnFormat, hasItem(project.tasks['licenseFormatAndroidAndroidTest'])
 

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
@@ -124,7 +124,7 @@ class LicensePluginTest {
         def task = project.tasks.create('licenseManual', License)
 
         Set<Task> dependsOn = project.tasks['check'].getDependsOn()
-        assertThat dependsOn, hasItem(project.tasks['license'])
+        assertThat dependsOn, hasItem(project.tasks.named('license'))
 
         // Manual tests don't get registered with check
         assertThat dependsOn, not(hasItem(task))
@@ -137,7 +137,7 @@ class LicensePluginTest {
         def task = project.tasks.create('licenseManual', LicenseCheck)
         def formatTask = project.tasks.create('licenseManualFormat', LicenseFormat)
 
-        Set<Task> dependsOn = project.tasks['license'].getDependsOn()
+        Set<Task> dependsOn = project.tasks['license'].getDependsOn().flatten()
         assertThat dependsOn, hasItem(project.tasks['licenseMain'])
         assertThat dependsOn, hasItem(project.tasks['licenseTest'])
         
@@ -145,7 +145,7 @@ class LicensePluginTest {
         assertThat dependsOn, hasItem(task)
         assertThat dependsOn, not(hasItem(formatTask))
 
-        Set<Task> dependsOnFormat = project.tasks['licenseFormat'].getDependsOn()
+        Set<Task> dependsOnFormat = project.tasks['licenseFormat'].getDependsOn().flatten()
         assertThat dependsOnFormat, hasItem(project.tasks['licenseFormatMain'])
         assertThat dependsOnFormat, hasItem(project.tasks['licenseFormatTest'])
 


### PR DESCRIPTION
This PR improves the plugin by registering tasks using [Task Configuration Avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html).

In a nutshell, the changes will register the Gradle tasks, but they will only be configured if they are actually required (i.e. when they will actually be executed), improving the time Gradle takes to configure everything.

I noticed that the plugin was configuring `downloadLicenses`, `license` and `licenseFormat` tasks even if a small Gradle task was run.

For demo purposes, I created a small demo project, which defines three modules, each having a simple `helloWorld` task whose only purpose is to print something to the console:
[LicenseGradlePluginLazyTaskConfigurationSample.zip](https://github.com/hierynomus/license-gradle-plugin/files/9234233/LicenseGradlePluginLazyTaskConfigurationSample.zip)

The project prints the tasks that are configured by Gradle to the console.

When running `./gradlew :module1:helloWorld` with the latest released plugin version, the console output looks as follows:

>$ ./gradlew :module1:helloWorld
>
> Configure project :
TASK CONFIGURED: :downloadLicenses
TASK CONFIGURED: :license
TASK CONFIGURED: :licenseFormat
TASK CONFIGURED: :module1:downloadLicenses
TASK CONFIGURED: :module1:license
TASK CONFIGURED: :module1:licenseFormat
TASK CONFIGURED: :module2:downloadLicenses
TASK CONFIGURED: :module2:license
TASK CONFIGURED: :module2:licenseFormat
TASK CONFIGURED: :module3:downloadLicenses
TASK CONFIGURED: :module3:license
TASK CONFIGURED: :module3:licenseFormat
>
> Configure project :module1
TASK CONFIGURED: :module1:check
TASK CONFIGURED: :module1:licenseMain
TASK CONFIGURED: :module1:licenseFormatMain
TASK CONFIGURED: :module1:licenseTest
TASK CONFIGURED: :module1:licenseFormatTest
>
> Configure project :module2
TASK CONFIGURED: :module2:check
TASK CONFIGURED: :module2:licenseMain
TASK CONFIGURED: :module2:licenseFormatMain
TASK CONFIGURED: :module2:licenseTest
TASK CONFIGURED: :module2:licenseFormatTest
>
> Configure project :module3
TASK CONFIGURED: :module3:check
TASK CONFIGURED: :module3:licenseMain
TASK CONFIGURED: :module3:licenseFormatMain
TASK CONFIGURED: :module3:licenseTest
TASK CONFIGURED: :module3:licenseFormatTest
TASK CONFIGURED: :module1:helloWorld
>
> Task :module1:helloWorld
Hello from module1
>
>BUILD SUCCESSFUL in 589ms
1 actionable task: 1 executed

As you can see, `downloadLicenses`, `license` and `licenseFormat` tasks are configured even if they are not run, also for modules that are not affected by the current Gradle run.

After my changes, the output looks as follows:

>$ ./gradlew :module1:helloWorld
TASK CONFIGURED: :module1:helloWorld
>
> Task :module1:helloWorld
Hello from module1
>
>BUILD SUCCESSFUL in 475ms
1 actionable task: 1 executed
